### PR TITLE
Make tokens have displayOptions

### DIFF
--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -9,6 +9,7 @@ import {
 import {
   EuiCode,
   EuiIcon,
+  EuiToken,
 } from '../../../../src/components';
 
 const iconHtmlWarning = () => (
@@ -126,6 +127,7 @@ export const IconExample = {
         </p>
       </div>
     ),
+    props: { EuiToken },
     demo: <Tokens />,
   }, {
     title: 'Machine learning icons',

--- a/src-docs/src/views/icon/tokens.js
+++ b/src-docs/src/views/icon/tokens.js
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import {
   EuiFlexGrid,
   EuiFlexItem,
   EuiPanel,
   EuiText,
-  EuiToken
+  EuiToken,
+  EuiSpacer,
 } from '../../../../src/components';
 
 const tokens = [
@@ -40,24 +41,68 @@ const tokens = [
 ];
 
 export default () => (
-  <EuiFlexGrid columns={4}>
-    {
-      tokens.map(token => (
-        <EuiFlexItem
-          className="guideDemo__icon"
-          key={token}
-          style={{ width: '200px' }}
-        >
-          <EuiPanel>
-            <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '8px' }}>
-              <EuiToken iconType={token}/>
-            </div>
-            <EuiText size="s">
-              <p>{token}</p>
-            </EuiText>
-          </EuiPanel>
-        </EuiFlexItem>
-      ))
-    }
-  </EuiFlexGrid>
+  <Fragment>
+    <EuiFlexGrid columns={4}>
+      {
+        tokens.map(token => (
+          <EuiFlexItem
+            className="guideDemo__icon"
+            key={token}
+          >
+            <EuiPanel>
+              <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '8px' }}>
+                <EuiToken iconType={token}/>
+              </div>
+              <EuiText size="s">
+                <p>{token}</p>
+              </EuiText>
+            </EuiPanel>
+          </EuiFlexItem>
+        ))
+      }
+    </EuiFlexGrid>
+
+    <EuiSpacer />
+
+    <EuiFlexGrid columns={4}>
+      <EuiFlexItem
+        className="guideDemo__icon"
+      >
+        <EuiPanel>
+          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '8px' }}>
+            <EuiToken
+              iconType="tokenEvent"
+              size="m"
+              displayOptions={{
+                color: 'tokenTint10',
+                shape: 'square',
+                isOpaque: true,
+              }}
+            />
+          </div>
+          <EuiText size="s">
+            <p>A custom token</p>
+          </EuiText>
+        </EuiPanel>
+      </EuiFlexItem>
+      <EuiFlexItem
+        className="guideDemo__icon"
+      >
+        <EuiPanel>
+          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '8px' }}>
+            <EuiToken
+              iconType="visMapCoordinate"
+              displayOptions={{
+                color: 'tokenTint05',
+                shape: 'circle',
+              }}
+            />
+          </div>
+          <EuiText size="s">
+            <p>A custom token</p>
+          </EuiText>
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGrid>
+  </Fragment>
 );

--- a/src/components/token/__snapshots__/token.test.js.snap
+++ b/src/components/token/__snapshots__/token.test.js.snap
@@ -3,6 +3,8 @@
 exports[`EuiToken is rendered 1`] = `
 <div
   class="euiToken euiToken--circle euiToken--tokenTint01 euiToken--small"
+  color="tokenTint01"
+  shape="square"
 >
   <svg
     class="euiIcon euiIcon--medium"

--- a/src/components/token/_token.scss
+++ b/src/components/token/_token.scss
@@ -16,7 +16,7 @@
 .euiToken--square {
   // These are pretty small elements, the standard size
   // is just slightly too large.
-  border-radius: 3px;
+  border-radius: $euiBorderRadius - 1px;
 }
 
 .euiToken--small {
@@ -38,6 +38,7 @@
 .euiToken--large {
   width: $euiSizeXL;
   height: $euiSizeXL;
+
   &.euiToken--rectangle {
     padding: 0 $euiSize
   }
@@ -71,10 +72,10 @@ $tokenTypes: (
       box-shadow: none;
     }
     
-    &.euiToken--solid-color {
+    &.euiToken--opaque {
       background-color: $tintValue;
       svg {
-        fill: white;
+        fill: $euiColorGhost;
       }
     }
     

--- a/src/components/token/index.js
+++ b/src/components/token/index.js
@@ -1,5 +1,4 @@
 export {
   EuiToken,
-  TYPES as TOKEN_TYPES,
   SIZES as TOKEN_SIZES
 } from './token';

--- a/src/components/token/token.js
+++ b/src/components/token/token.js
@@ -31,10 +31,9 @@ export const EuiToken = ({
   // Check if display options is empty
   const displayOptionsIsEmpty = Object.keys(displayOptions).length === 0 && displayOptions.constructor === Object;
 
-  // Set some defaults for our displayOptions in case they only use some of them
-  let tokenShape = 'square';
-  let tokenColor = 'tokenTint01';
-  let tokenIsOpaque = false;
+  let tokenShape;
+  let tokenColor;
+  let tokenIsOpaque;
 
   // Check if this has a mapping, and doesn't have custom displayOptions
   if ((iconType in TOKEN_MAP) && (displayOptionsIsEmpty)) {
@@ -42,8 +41,9 @@ export const EuiToken = ({
     tokenColor = TOKEN_MAP[iconType].color;
     tokenIsOpaque = (TOKEN_MAP[iconType].isOpaque ? true : false);
   } else {
-    tokenShape = displayOptions.shape;
-    tokenColor = displayOptions.color;
+    // Use the displayOptions passed or use some defaults
+    tokenShape = displayOptions.shape ? displayOptions.shape : 'square';
+    tokenColor = displayOptions.color ? displayOptions.color : 'tokenTint01';
     tokenIsOpaque = displayOptions.isOpaque ? true : false;
   }
 

--- a/src/components/token/token.js
+++ b/src/components/token/token.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { EuiIcon } from '../icon';
+import { ICON_TYPES, EuiIcon } from '../icon';
 import { TOKEN_MAP } from './token_map';
 
 const sizeToClassMap = {
@@ -22,39 +22,38 @@ export const SHAPES = Object.keys(shapeToClassMap);
 
 export const EuiToken = ({
   iconType,
+  displayOptions,
   size,
-  shape,
-  color,
-  isSolidColor,
-  hideBorder,
   className,
   ...rest,
 }) => {
 
-  console.log(TOKEN_MAP[iconType].shape);
+  // Check if display options is empty
+  const displayOptionsIsEmpty = Object.keys(displayOptions).length === 0 && displayOptions.constructor === Object;
 
-  if (iconType in TOKEN_MAP) {
-    shape = TOKEN_MAP[iconType].shape;
-    color = TOKEN_MAP[iconType].color;
-    iconType = iconType;
-    if (TOKEN_MAP[iconType].isSolidColor) {
-      isSolidColor = true;
-    }
-    if (TOKEN_MAP[iconType].hideBorder) {
-      hideBorder = true;
-    }
+  // Set some defaults for our displayOptions in case they only use some of them
+  let tokenShape = 'square';
+  let tokenColor = 'tokenTint01';
+  let tokenIsOpaque = false;
+
+  // Check if this has a mapping, and doesn't have custom displayOptions
+  if ((iconType in TOKEN_MAP) && (displayOptionsIsEmpty)) {
+    tokenShape = TOKEN_MAP[iconType].shape;
+    tokenColor = TOKEN_MAP[iconType].color;
+    tokenIsOpaque = (TOKEN_MAP[iconType].isOpaque ? true : false);
+  } else {
+    tokenShape = displayOptions.shape;
+    tokenColor = displayOptions.color;
+    tokenIsOpaque = displayOptions.isOpaque ? true : false;
   }
 
   const classes = classNames(
     'euiToken',
-    `euiToken--${shape}`,
-    `euiToken--${color}`,
+    `euiToken--${tokenShape}`,
+    `euiToken--${tokenColor}`,
     sizeToClassMap[size],
     {
-      'euiToken--solid-color': isSolidColor
-    },
-    {
-      'euiToken--no-border': hideBorder
+      'euiToken--opaque': tokenIsOpaque
     },
     className
   );
@@ -70,14 +69,28 @@ export const EuiToken = ({
 };
 
 EuiToken.propTypes = {
-  iconType: PropTypes.string.isRequired,
-  color: PropTypes.string.isRequired,
-  isSolidColor: PropTypes.bool,
-  hideBorder: PropTypes.bool,
-  shape: PropTypes.oneOf(SHAPES).isRequired,
-  size: PropTypes.oneOf(SIZES),
+  /**
+   * An EUI icon type
+   */
+  iconType: PropTypes.oneOf(ICON_TYPES).isRequired,
+  /**
+   * Size of the token
+   */
+  size: PropTypes.oneOf(SIZES).isRequired,
+  /**
+   * By default EUI will auto color tokens. You can can however control it
+   * `color`: can be `tokenTint01` thru `tokenTint10`
+   * - `shape`: square, circle, rectangle as options
+   * - `isOpaque`: makes it a solid color
+   */
+  displayOptions: PropTypes.shape({
+    color: PropTypes.string,
+    shape: PropTypes.string,
+    isOpaque: PropTypes.boolean,
+  }),
 };
 
 EuiToken.defaultProps = {
-  size: 's'
+  size: 's',
+  displayOptions: {},
 };

--- a/src/components/token/token_map.js
+++ b/src/components/token/token_map.js
@@ -1,117 +1,124 @@
+// Sets default displayOptions for EuiTokes based on iconType
+// tokenClass: {
+//   'shape': 'square',
+//   'color': 'tokenTint01',
+//   'isOpaque': false,
+// },
+
 export const TOKEN_MAP = {
   tokenClass: {
     'shape': 'circle',
-    'color': 'tokenTint01'
+    'color': 'tokenTint01',
   },
   tokenProperty: {
     'shape': 'circle',
-    'color': 'tokenTint02'
+    'color': 'tokenTint02',
   },
   tokenEnum: {
     'shape': 'circle',
-    'color': 'tokenTint03'
+    'color': 'tokenTint03',
   },
   tokenVariable: {
     'shape': 'circle',
-    'color': 'tokenTint04'
+    'color': 'tokenTint04',
   },
   tokenMethod: {
     'shape': 'square',
-    'color': 'tokenTint02'
+    'color': 'tokenTint02',
   },
   tokenAnnotation: {
     'shape': 'square',
-    'color': 'tokenTint06'
+    'color': 'tokenTint06',
   },
   tokenException: {
     'shape': 'circle',
-    'color': 'tokenTint07'
+    'color': 'tokenTint07',
   },
   tokenInterface: {
     'shape': 'circle',
-    'color': 'tokenTint08'
+    'color': 'tokenTint08',
   },
   tokenParameter: {
     'shape': 'square',
-    'color': 'tokenTint09'
+    'color': 'tokenTint09',
   },
   tokenField: {
     'shape': 'circle',
-    'color': 'tokenTint10'
+    'color': 'tokenTint10',
   },
   tokenElement: {
     'shape': 'square',
-    'color': 'tokenTint03'
+    'color': 'tokenTint03',
   },
   tokenFunction: {
     'shape': 'circle',
-    'color': 'tokenTint02'
+    'color': 'tokenTint02',
   },
   tokenBoolean: {
     'shape': 'square',
-    'color': 'tokenTint05'
+    'color': 'tokenTint05',
   },
   tokenString: {
     'shape': 'square',
-    'color': 'tokenTint07'
+    'color': 'tokenTint07',
   },
   tokenArray: {
     'shape': 'square',
-    'color': 'tokenTint04'
+    'color': 'tokenTint04',
   },
   tokenNumber: {
     'shape': 'circle',
-    'color': 'tokenTint05'
+    'color': 'tokenTint05',
   },
   tokenConstant: {
     'shape': 'circle',
-    'color': 'tokenTint07'
+    'color': 'tokenTint07',
   },
   tokenObject: {
     'shape': 'square',
-    'color': 'tokenTint03'
+    'color': 'tokenTint03',
   },
   tokenEvent: {
     'shape': 'circle',
-    'color': 'tokenTint09'
+    'color': 'tokenTint09',
   },
   tokenKey: {
     'shape': 'circle',
-    'color': 'tokenTint06'
+    'color': 'tokenTint06',
   },
   tokenNull: {
     'shape': 'square',
-    'color': 'tokenTint02'
+    'color': 'tokenTint02',
   },
   tokenStruct: {
     'shape': 'square',
-    'color': 'tokenTint07'
+    'color': 'tokenTint07',
   },
   tokenPackage: {
     'shape': 'square',
-    'color': 'tokenTint10'
+    'color': 'tokenTint10',
   },
   tokenOperator: {
     'shape': 'circle',
-    'color': 'tokenTint09'
+    'color': 'tokenTint09',
   },
   tokenEnumMember: {
     'shape': 'square',
-    'color': 'tokenTint04'
+    'color': 'tokenTint04',
   },
   tokenTypeRepo: {
     'shape': 'rectangle',
     'color': 'tokenTint05',
-    'isSolidColor': true
+    'isOpaque': true,
   },
   tokenTypeSymbol: {
     'shape': 'rectangle',
     'color': 'tokenTint07',
-    'isSolidColor': true
+    'isOpaque': true,
   },
   tokenTypeFile: {
     'shape': 'rectangle',
     'color': 'tokenTint12',
-    'isSolidColor': true
+    'isOpaque': true,
   },
 };


### PR DESCRIPTION
### Summary

Had some time (and felt bad for my lack of help over zoom). Cleaned up the props on the component and made it more flexible. Can discuss if you want a run-thru of the changes.

* There is now a `displayOptions` prop for setting color, shape, and opaque/solidness (didn't like my name any better than yours!)
* Added two docs examples examples to show how to set custom token displayOptions.
* Properly set up autodocs (I'll show you how this works)

### Stuff we should probably do still

* `EuiToken` should probably have its own docs page and not be on the Icon page (maybe?). The new page should have two examples
    * One showing the default token coloring.
    * One showing the  custom token examples
* We might want to consider displaying the `token*` icons in their own section within the `EuiIcon` docs page. Right now they're smushed at the end when everything else is alphabetical. It might give us a better chance to explain them.
* Prolly can come up with better naming thatn `opaque` and `tokenTintXX`. I didn't have any better ideas but something feels weird. Naming is hard.
* Still a decision with non-"token" icons? Should we allow any icon to be used as I'm doing with the map marker below? If not, we can make some regex to dissallow icons that don't start with `token`.

![image](https://user-images.githubusercontent.com/324519/47768509-9ef69c80-dc95-11e8-8adc-bdc5f3fb6a63.png)

