### PR TITLE
EUI design patterns for tree

### DIFF
--- a/src-docs/src/views/tree_view/compressed.js
+++ b/src-docs/src/views/tree_view/compressed.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { EuiTreeView, EuiToken } from '../../../../src/components';
 
-export class TreeViewCondensed extends React.Component {
+export class TreeViewCompressed extends React.Component {
   showAlert = () => {
     alert('You squashed a bug!');
   };
@@ -85,7 +85,7 @@ export class TreeViewCondensed extends React.Component {
       <div style={{ width: '20rem' }}>
         <EuiTreeView
           items={items}
-          isCondensed
+          display="compressed"
           expandByDefault
           showExpansionArrows
           aria-label="Document Outline"

--- a/src-docs/src/views/tree_view/tree_view_example.js
+++ b/src-docs/src/views/tree_view/tree_view_example.js
@@ -7,13 +7,13 @@ import { GuideSectionTypes } from '../../components';
 import { EuiCode, EuiTreeView } from '../../../../src/components';
 import { EuiTreeViewNode } from './tree_view_props';
 import { TreeView } from './tree_view';
-import { TreeViewCondensed } from './condensed';
+import { TreeViewCompressed } from './compressed';
 
 const treeViewSource = require('!!raw-loader!./tree_view');
 const treeViewHtml = renderToHtml(TreeView);
 
-const treeViewCondensedSource = require('!!raw-loader!./condensed');
-const treeViewCondensedHtml = renderToHtml(TreeViewCondensed);
+const treeViewCompressedSource = require('!!raw-loader!./compressed');
+const treeViewCompressedHtml = renderToHtml(TreeViewCompressed);
 
 export const TreeViewExample = {
   title: 'Tree View',
@@ -53,24 +53,24 @@ export const TreeViewExample = {
       props: { EuiTreeView, EuiTreeViewNode },
     },
     {
-      title: 'Condensed version',
+      title: 'Optional styling',
       source: [
         {
           type: GuideSectionTypes.JS,
-          code: treeViewCondensedSource,
+          code: treeViewCompressedSource,
         },
         {
           type: GuideSectionTypes.HTML,
-          code: treeViewCondensedHtml,
+          code: treeViewCompressedHtml,
         },
       ],
       text: (
         <div>
           <p>
-            <EuiCode>EuiTreeView</EuiCode> supports a condensed mode with the{' '}
-            <EuiCode>isCondensed</EuiCode> prop. When using the condensed
-            version it&apos;s highly recommended to use the small size of{' '}
-            <EuiCode>EuiIcon</EuiCode> and the extra small size of{' '}
+            <EuiCode>EuiTreeView</EuiCode> supports a compressed mode with the{' '}
+            <EuiCode>display=&quot;compressed&quot;</EuiCode> setting. When
+            using the compressed version it&apos;s highly recommended to use the
+            small size of <EuiCode>EuiIcon</EuiCode> and the extra small size of{' '}
             <EuiCode>EuiToken</EuiCode>. This will help prevent awkard alignment
             issues when used alongside the{' '}
             <EuiCode>showExpansionArrows</EuiCode> prop.
@@ -90,7 +90,7 @@ export const TreeViewExample = {
         </div>
       ),
       components: { EuiTreeView },
-      demo: <TreeViewCondensed />,
+      demo: <TreeViewCompressed />,
       props: { EuiTreeView, EuiTreeViewNode },
     },
   ],

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -30,7 +30,7 @@
   text-align-last: left;
 
   &:focus {
-    box-shadow: inset 0 0 0 $euiSizeXS / 4 $euiColorPrimary;
+    box-shadow: inset 0 0 0 $euiSizeXS / 4 $euiFocusRingColor;
   }
 
   &:hover,
@@ -54,7 +54,7 @@
   }
 }
 
-.euiTreeView--condensed {
+.euiTreeView--compressed {
   .euiTreeView__node {
     max-height: $euiSizeL;
     line-height: $euiSizeL;
@@ -100,7 +100,7 @@
     }
   }
 
-  &.euiTreeView--condensed {
+  &.euiTreeView--compressed {
     .euiTreeView__nodeInner--withArrows {
       .euiTreeView__iconWrapper {
         margin-left: 0;

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -46,6 +46,15 @@ export interface Node {
   callback?(): string;
 }
 
+export type EuiTreeViewDisplayOptions = 'default' | 'compressed';
+
+const displayToClassNameMap: {
+  [option in EuiTreeViewDisplayOptions]: string | null
+} = {
+  default: null,
+  compressed: 'euiTreeView--compressed',
+};
+
 interface EuiTreeViewState {
   openItems: string[];
   activeItem: string;
@@ -60,7 +69,7 @@ export type CommonTreeProps = CommonProps &
     items: Node[];
     /** Optionally use a variation with smaller text and icon sizes
      */
-    isCondensed?: boolean;
+    display?: EuiTreeViewDisplayOptions;
     /** Set all items to open on initial load
      */
     expandByDefault?: boolean;
@@ -201,7 +210,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
       children,
       className,
       items,
-      isCondensed,
+      display = 'default',
       expandByDefault,
       showExpansionArrows,
       ...rest
@@ -210,7 +219,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
     // Computed classNames
     const classes = classNames(
       'euiTreeView',
-      { 'euiTreeView--condensed': isCondensed },
+      display ? displayToClassNameMap[display] : null,
       { 'euiTreeView--withArrows': showExpansionArrows },
       className
     );
@@ -220,7 +229,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
     return (
       <EuiTreeViewContext.Provider value={this.state.treeID}>
         <EuiText
-          size={isCondensed ? 's' : 'm'}
+          size={display === 'compressed' ? 's' : 'm'}
           className="euiTreeView__wrapper">
           {!this.isNested && (
             <EuiScreenReaderOnly>
@@ -296,7 +305,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                             {showExpansionArrows && node.children ? (
                               <EuiIcon
                                 className="euiTreeView__expansionArrow"
-                                size={isCondensed ? 's' : 'm'}
+                                size={display === 'compressed' ? 's' : 'm'}
                                 type={
                                   this.isNodeOpen(node)
                                     ? 'arrowDown'
@@ -326,7 +335,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                             {node.children && this.isNodeOpen(node) ? (
                               <EuiTreeView
                                 items={node.children}
-                                isCondensed={isCondensed}
+                                display={display}
                                 showExpansionArrows={showExpansionArrows}
                                 expandByDefault={this.state.expandChildNodes}
                                 {...label}


### PR DESCRIPTION
### Summary

Makes the following changes

* Use an enum for the styling difference. Never know what someone will want later. Use `compressed` instead of `condensed` to match EUI nameing.
* Move to `euiFocusRing` for coloring to stay closer to EUI patterns
* Update docs to match
