### PR TITLE
Control bar

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -196,6 +196,8 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   left: 0;
   height: 100%;
   width: 100%;
+  padding: 2rem;
+  z-index: $euiZMask - 1;
 }
 
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -189,6 +189,16 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   margin-right: $euiSizeS;
 }
 
+.guideDemo__pageOverlay {
+  background-color: $euiColorLightestShade;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+
 .guideCharts__customLegendLine--thin {
   height: 1px;
 }

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -160,17 +160,6 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   width: $euiSize * 16;
 }
 
-.guideDemo__pageOverlay {
-  background-color: $euiColorLightestShade;
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  padding: 2rem;
-  z-index: 5999;
-}
-
 .guideCharts__customLegend {
   font-size: $euiFontSizeXS;
   position: absolute;
@@ -188,18 +177,6 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   vertical-align: middle;
   margin-right: $euiSizeS;
 }
-
-.guideDemo__pageOverlay {
-  background-color: $euiColorLightestShade;
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  padding: 2rem;
-  z-index: $euiZMask - 1;
-}
-
 
 .guideCharts__customLegendLine--thin {
   height: 1px;

--- a/src-docs/src/views/control_bar/control_bar.js
+++ b/src-docs/src/views/control_bar/control_bar.js
@@ -3,12 +3,9 @@ import React, { Component } from 'react';
 import {
   EuiButton,
   EuiControlBar,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiPanel,
   EuiText,
 } from '../../../../src/components';
-import { EuiFocusTrap } from '../../../../src/components/focus_trap';
 import { keyCodes } from '../../../../src/services';
 
 export default class extends Component {
@@ -16,29 +13,29 @@ export default class extends Component {
     super(props);
     this.state = {
       contentIsVisible: false,
-      isFullScreen: false,
+      isDisplaying: false,
     };
   }
 
-  toggle() {
+  toggleContent = () => {
     this.setState(prevState => ({
       contentIsVisible: !prevState.contentIsVisible,
     }));
-  }
+  };
 
-  toggleFullScreen() {
+  toggleDisplay = () => {
     this.setState(prevState => ({
-      isFullScreen: !prevState.isFullScreen,
+      isDisplaying: !prevState.isDisplaying,
       contentIsVisible: false,
     }));
-  }
+  };
 
   onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
       event.preventDefault();
       event.stopPropagation();
       this.setState({
-        isFullScreen: false,
+        isDisplaying: false,
         contentIsVisible: false,
       });
     }
@@ -47,15 +44,14 @@ export default class extends Component {
   render() {
     const codeControls = [
       {
-        id: 'root_icon',
-        label: 'Project Root',
         controlType: 'icon',
+        id: 'root_icon',
         iconType: 'submodule',
+        'aria-label': 'Project Root',
       },
       {
-        id: 'current_file_path',
-        label: 'breadcrumbs',
         controlType: 'breadcrumbs',
+        id: 'current_file_path',
         responsive: true,
         breadcrumbs: [
           {
@@ -70,135 +66,114 @@ export default class extends Component {
         controlType: 'spacer',
       },
       {
-        id: 'status_icon',
-        label: 'Repo Status',
         controlType: 'icon',
+        id: 'status_icon',
         iconType: 'alert',
         color: 'warning',
+        'aria-label': 'Repo Status',
       },
       {
         controlType: 'divider',
       },
       {
+        controlType: 'icon',
         id: 'branch_icon',
-        label: 'Branch Icon',
         iconType: 'branch',
-        controlType: 'icon',
+        'aria-label': 'Branch Icon',
       },
       {
-        id: 'branch_name',
-        label: 'some_long_branch',
         controlType: 'text',
+        id: 'branch_name',
+        text: 'some_long_branch',
       },
       {
         controlType: 'divider',
       },
       {
-        id: 'github_icon',
-        label: 'Open in Github',
         controlType: 'icon',
+        id: 'github_icon',
         iconType: 'logoGithub',
+        onClick: () => {},
+        title: 'Open in Github',
+        'aria-label': 'Open in Github',
       },
       {
         controlType: 'divider',
       },
       {
-        id: 'open_code_view',
-        label: 'Code',
         controlType: 'button',
-      },
-      {
-        id: 'open_blame_view',
-        label: 'Blame',
-        controlType: 'button',
-      },
-      {
         id: 'open_history_view',
-        label: 'History',
-        controlType: 'button',
+        label: this.state.contentIsVisible ? 'Hide history' : 'Show history',
+        color: 'primary',
+        onClick: this.toggleContent,
       },
     ];
 
-    let fullScreenDisplay;
+    let display;
 
-    if (this.state.isFullScreen) {
-      fullScreenDisplay = (
-        <EuiFocusTrap>
-          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
-            <EuiFlexGroup>
-              <EuiButton onClick={this.toggle.bind(this)}>
-                Toggle Content Drawer
-              </EuiButton>
-              <EuiFlexItem grow />
-              <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-                Close
-              </EuiButton>
-            </EuiFlexGroup>
-            <EuiControlBar
-              controls={codeControls}
-              showContent={this.state.contentIsVisible}
-              showOnMobile>
-              <EuiPanel style={{ maxWidth: '60rem', margin: '2rem auto' }}>
-                <EuiText>
-                  <h1>1984</h1>
-                  <h3>By: George Orwell</h3>
-                  <p>
-                    It was a bright cold day in April, and the clocks were
-                    striking thirteen. Winston Smith, his chin nuzzled into his
-                    breast in an effort to escape the vile wind, slipped quickly
-                    through the glass doors of Victory Mansions, though not
-                    quickly enough to prevent a swirl of gritty dust from
-                    entering along with him.
-                  </p>
-                  <p>
-                    The hallway smelt of boiled cabbage and old rag mats. At one
-                    end of it a coloured poster, too large for indoor display,
-                    had been tacked to the wall. It depicted simply an enormous
-                    face, more than a metre wide: the face of a man of about
-                    forty-five, with a heavy black moustache and ruggedly
-                    handsome features. Winston made for the stairs. It was no
-                    use trying the lift. Even at the best of times it was seldom
-                    working, and at present the electric current was cut off
-                    during daylight hours. It was part of the economy drive in
-                    preparation for Hate Week. The flat was seven flights up,
-                    and Winston, who was thirty-nine and had a varicose ulcer
-                    above his right ankle, went slowly, resting several times on
-                    the way. On each landing, opposite the lift-shaft, the
-                    poster with the enormous face gazed from the wall. It was
-                    one of those pictures which are so contrived that the eyes
-                    follow you about when you move. BIG BROTHER IS WATCHING YOU,
-                    the caption beneath it ran.
-                  </p>
-                  <p>
-                    Inside the flat a fruity voice was reading out a list of
-                    figures which had something to do with the production of
-                    pig-iron. The voice came from an oblong metal plaque like a
-                    dulled mirror which formed part of the surface of the
-                    right-hand wall. Winston turned a switch and the voice sank
-                    somewhat, though the words were still distinguishable. The
-                    instrument (the telescreen, it was called) could be dimmed,
-                    but there was no way of shutting it off completely. He moved
-                    over to the window: a smallish, frail figure, the meagreness
-                    of his body merely emphasized by the blue overalls which
-                    were the uniform of the party. His hair was very fair, his
-                    face naturally sanguine, his skin roughened by coarse soap
-                    and blunt razor blades and the cold of the winter that had
-                    just ended.
-                  </p>
-                </EuiText>
-              </EuiPanel>
-            </EuiControlBar>
+    if (this.state.isDisplaying) {
+      display = (
+        <EuiControlBar
+          controls={codeControls}
+          showContent={this.state.contentIsVisible}>
+          <div style={{ padding: '2rem', maxWidth: '60rem', margin: '0 auto' }}>
+            <EuiPanel>
+              <EuiText>
+                <h1>1984</h1>
+                <h3>By: George Orwell</h3>
+                <p>
+                  It was a bright cold day in April, and the clocks were
+                  striking thirteen. Winston Smith, his chin nuzzled into his
+                  breast in an effort to escape the vile wind, slipped quickly
+                  through the glass doors of Victory Mansions, though not
+                  quickly enough to prevent a swirl of gritty dust from entering
+                  along with him.
+                </p>
+                <p>
+                  The hallway smelt of boiled cabbage and old rag mats. At one
+                  end of it a coloured poster, too large for indoor display, had
+                  been tacked to the wall. It depicted simply an enormous face,
+                  more than a metre wide: the face of a man of about forty-five,
+                  with a heavy black moustache and ruggedly handsome features.
+                  Winston made for the stairs. It was no use trying the lift.
+                  Even at the best of times it was seldom working, and at
+                  present the electric current was cut off during daylight
+                  hours. It was part of the economy drive in preparation for
+                  Hate Week. The flat was seven flights up, and Winston, who was
+                  thirty-nine and had a varicose ulcer above his right ankle,
+                  went slowly, resting several times on the way. On each
+                  landing, opposite the lift-shaft, the poster with the enormous
+                  face gazed from the wall. It was one of those pictures which
+                  are so contrived that the eyes follow you about when you move.
+                  BIG BROTHER IS WATCHING YOU, the caption beneath it ran.
+                </p>
+                <p>
+                  Inside the flat a fruity voice was reading out a list of
+                  figures which had something to do with the production of
+                  pig-iron. The voice came from an oblong metal plaque like a
+                  dulled mirror which formed part of the surface of the
+                  right-hand wall. Winston turned a switch and the voice sank
+                  somewhat, though the words were still distinguishable. The
+                  instrument (the telescreen, it was called) could be dimmed,
+                  but there was no way of shutting it off completely. He moved
+                  over to the window: a smallish, frail figure, the meagreness
+                  of his body merely emphasized by the blue overalls which were
+                  the uniform of the party. His hair was very fair, his face
+                  naturally sanguine, his skin roughened by coarse soap and
+                  blunt razor blades and the cold of the winter that had just
+                  ended.
+                </p>
+              </EuiText>
+            </EuiPanel>
           </div>
-        </EuiFocusTrap>
+        </EuiControlBar>
       );
     }
 
     return (
       <div>
-        <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-          View in Full Screen
-        </EuiButton>
-        {fullScreenDisplay}
+        <EuiButton onClick={this.toggleDisplay}>Toggle example</EuiButton>
+        {display}
       </div>
     );
   }

--- a/src-docs/src/views/control_bar/control_bar.js
+++ b/src-docs/src/views/control_bar/control_bar.js
@@ -54,6 +54,7 @@ export default class extends Component {
       },
       {
         id: 'current_file_path',
+        label: 'breadcrumbs',
         controlType: 'breadcrumbs',
         responsive: true,
         breadcrumbs: [
@@ -66,6 +67,7 @@ export default class extends Component {
         ],
       },
       {
+        id: 'spacer_1',
         controlType: 'spacer',
       },
       {
@@ -76,6 +78,7 @@ export default class extends Component {
         color: 'warning',
       },
       {
+        id: 'divider_one',
         controlType: 'divider',
       },
       {
@@ -86,10 +89,11 @@ export default class extends Component {
       },
       {
         id: 'branch_name',
-        label: 'some_long_branch',
+        label: 'some_long_bran...',
         controlType: 'text',
       },
       {
+        id: 'divider_two',
         controlType: 'divider',
       },
       {
@@ -99,6 +103,7 @@ export default class extends Component {
         iconType: 'logoGithub',
       },
       {
+        id: 'divider_three',
         controlType: 'divider',
       },
       {
@@ -120,10 +125,31 @@ export default class extends Component {
 
     let fullScreenDisplay;
 
+    // const controlBar = (
+    //   <EuiControlBar
+    //     controls={codeControls}
+    //     showContent={this.state.contentIsVisible}
+    //     style={!this.state.isFullScreen ? { position: 'absolute' } : null}>
+    //     <div style={{ padding: '1rem' }}>
+    //       {this.state.tabContent !== '' ? (
+    //         <EuiText>{this.state.tabContent}</EuiText>
+    //       ) : (
+    //         <p>Look at me</p>
+    //       )}
+    //     </div>
+    //   </EuiControlBar>
+    // );
+
     if (this.state.isFullScreen) {
       fullScreenDisplay = (
         <EuiFocusTrap>
-          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
+          <div
+            className="guideDemo__pageOverlay"
+            style={{
+              padding: '2rem',
+              zIndex: '20000',
+            }}
+            onKeyDown={this.onKeyDown}>
             <EuiFlexGroup>
               <EuiButton onClick={this.toggle.bind(this)}>
                 Toggle Content Drawer
@@ -135,8 +161,7 @@ export default class extends Component {
             </EuiFlexGroup>
             <EuiControlBar
               controls={codeControls}
-              showContent={this.state.contentIsVisible}
-              showOnMobile>
+              showContent={this.state.contentIsVisible}>
               <EuiPanel style={{ maxWidth: '60rem', margin: '2rem auto' }}>
                 <EuiText>
                   <h1>1984</h1>

--- a/src-docs/src/views/control_bar/control_bar.js
+++ b/src-docs/src/views/control_bar/control_bar.js
@@ -67,7 +67,6 @@ export default class extends Component {
         ],
       },
       {
-        id: 'spacer_1',
         controlType: 'spacer',
       },
       {
@@ -78,7 +77,6 @@ export default class extends Component {
         color: 'warning',
       },
       {
-        id: 'divider_one',
         controlType: 'divider',
       },
       {
@@ -89,11 +87,10 @@ export default class extends Component {
       },
       {
         id: 'branch_name',
-        label: 'some_long_bran...',
+        label: 'some_long_branch',
         controlType: 'text',
       },
       {
-        id: 'divider_two',
         controlType: 'divider',
       },
       {
@@ -103,7 +100,6 @@ export default class extends Component {
         iconType: 'logoGithub',
       },
       {
-        id: 'divider_three',
         controlType: 'divider',
       },
       {
@@ -125,31 +121,10 @@ export default class extends Component {
 
     let fullScreenDisplay;
 
-    // const controlBar = (
-    //   <EuiControlBar
-    //     controls={codeControls}
-    //     showContent={this.state.contentIsVisible}
-    //     style={!this.state.isFullScreen ? { position: 'absolute' } : null}>
-    //     <div style={{ padding: '1rem' }}>
-    //       {this.state.tabContent !== '' ? (
-    //         <EuiText>{this.state.tabContent}</EuiText>
-    //       ) : (
-    //         <p>Look at me</p>
-    //       )}
-    //     </div>
-    //   </EuiControlBar>
-    // );
-
     if (this.state.isFullScreen) {
       fullScreenDisplay = (
         <EuiFocusTrap>
-          <div
-            className="guideDemo__pageOverlay"
-            style={{
-              padding: '2rem',
-              zIndex: '20000',
-            }}
-            onKeyDown={this.onKeyDown}>
+          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
             <EuiFlexGroup>
               <EuiButton onClick={this.toggle.bind(this)}>
                 Toggle Content Drawer
@@ -161,7 +136,8 @@ export default class extends Component {
             </EuiFlexGroup>
             <EuiControlBar
               controls={codeControls}
-              showContent={this.state.contentIsVisible}>
+              showContent={this.state.contentIsVisible}
+              showOnMobile>
               <EuiPanel style={{ maxWidth: '60rem', margin: '2rem auto' }}>
                 <EuiText>
                   <h1>1984</h1>

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -29,20 +29,17 @@ const controlsHtml = renderToHtml(Controls);
 const controlBarSource = require('!!raw-loader!./control_bar');
 const controlBarHtml = renderToHtml(ControlBar);
 const controlBarSnippet = `<EuiControlBar
-  size="l"
   showContent={false}
-  navDrawerOffset="s"
   controls={
     [{
-      id: 'root_icon',
-      label: 'Project Root',
-      controlType: 'icon',
       iconType: 'submodule',
+      id: 'root_icon',
+      controlType: 'icon',
+      'aria-label': 'Project Root',
     },
     {
-      id: 'current_file_path',
-      label: 'breadcrumbs',
       controlType: 'breadcrumbs',
+      id: 'current_file_path',
       responsive: true,
       breadcrumbs: [
         {
@@ -57,14 +54,21 @@ const controlBarSnippet = `<EuiControlBar
       controlType: 'spacer',
     },
     {
-      id: 'status_icon',
-      label: 'Repo Status',
       controlType: 'icon',
+      id: 'status_icon',
       iconType: 'alert',
       color: 'warning',
+      'aria-label': 'Repo Status',
     },
     {
       controlType: 'divider',
+    },
+    {
+      controlType: 'button',
+      id: 'open_history_view',
+      label: 'Show history',
+      color: 'primary',
+      onClick: this.toggleContent,
     }]
   }
 />`;
@@ -79,18 +83,17 @@ const mobileBarSnippet = `<EuiControlBar
   showOnMobile
   controls={[
     {
-      id: 'icon',
       controlType: 'icon',
-      label: 'folder',
+      id: 'icon',
       iconType: 'folderClosed',
+      'aria-label': 'folder',
       className: 'eui-hideFor--m eui-hideFor--l eui-hideFor--xl',
     },
     {
-      id: 'current_file_path',
-      label: 'breadcrumbs',
       controlType: 'breadcrumbs',
-      responsive: true,
+      id: 'current_file_path',
       className: 'eui-hideFor--s eui-hideFor--xs',
+      responsive: true,
       breadcrumbs: [
         {
           text: 'src',
@@ -104,14 +107,14 @@ const mobileBarSnippet = `<EuiControlBar
       controlType: 'spacer',
     },
     {
-      id: 'github_icon',
       controlType: 'icon',
+      id: 'github_icon',
       iconType: 'logoGithub',
     },
     {
-      id: 'github_text',
       controlType: 'text',
-      label: 'Open in Github',
+      id: 'github_text',
+      text: 'Open in Github',
     },
   ]}/>`;
 

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -15,7 +15,46 @@ import { ControlBarWithTabs } from './tabs';
 
 const controlBarSource = require('!!raw-loader!./control_bar');
 const controlBarHtml = renderToHtml(ControlBar);
-const controlBarSnippet = '<EuiControlBar controls={items}/>';
+const controlBarSnippet = `<EuiControlBar
+  size="l"
+  showContent={false}
+  navDrawerOffset="s"
+  controls={
+    [{
+      id: 'root_icon',
+      label: 'Project Root',
+      controlType: 'icon',
+      iconType: 'submodule',
+    },
+    {
+      id: 'current_file_path',
+      label: 'breadcrumbs',
+      controlType: 'breadcrumbs',
+      responsive: true,
+      breadcrumbs: [
+        {
+          text: 'src',
+        },
+        {
+          text: 'components',
+        },
+      ],
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      id: 'status_icon',
+      label: 'Repo Status',
+      controlType: 'icon',
+      iconType: 'alert',
+      color: 'warning',
+    },
+    {
+      controlType: 'divider',
+    }]
+  }
+/>`;
 
 const tabsBarSource = require('!!raw-loader!./tabs');
 const tabsBarHtml = renderToHtml(ControlBarWithTabs);

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -12,96 +12,14 @@ import { GuideSectionTypes } from '../../components';
 
 import ControlBar from './control_bar';
 import { ControlBarWithTabs } from './tabs';
-import { ControlBarMobile } from './mobile';
 
 const controlBarSource = require('!!raw-loader!./control_bar');
 const controlBarHtml = renderToHtml(ControlBar);
-const controlBarSnippet = `<EuiControlBar
-  size="l"
-  showContent={false}
-  navDrawerOffset="s"
-  controls={
-    [{
-      id: 'root_icon',
-      label: 'Project Root',
-      controlType: 'icon',
-      iconType: 'submodule',
-    },
-    {
-      id: 'current_file_path',
-      label: 'breadcrumbs',
-      controlType: 'breadcrumbs',
-      responsive: true,
-      breadcrumbs: [
-        {
-          text: 'src',
-        },
-        {
-          text: 'components',
-        },
-      ],
-    },
-    {
-      controlType: 'spacer',
-    },
-    {
-      id: 'status_icon',
-      label: 'Repo Status',
-      controlType: 'icon',
-      iconType: 'alert',
-      color: 'warning',
-    },
-    {
-      controlType: 'divider',
-    }]
-  }
-/>`;
+const controlBarSnippet = '<EuiControlBar controls={items}/>';
 
 const tabsBarSource = require('!!raw-loader!./tabs');
 const tabsBarHtml = renderToHtml(ControlBarWithTabs);
 const tabsBarSnippet = '<EuiControlBar controls={items} size="m"/>';
-
-const mobileBarSource = require('!!raw-loader!./mobile');
-const mobileBarHtml = renderToHtml(ControlBarMobile);
-const mobileBarSnippet = `<EuiControlBar
-  showOnMobile
-  controls={[
-    {
-      id: 'icon',
-      controlType: 'icon',
-      label: 'folder',
-      iconType: 'folderClosed',
-      className: 'eui-hideFor--m eui-hideFor--l eui-hideFor--xl',
-    },
-    {
-      id: 'current_file_path',
-      label: 'breadcrumbs',
-      controlType: 'breadcrumbs',
-      responsive: true,
-      className: 'eui-hideFor--s eui-hideFor--xs',
-      breadcrumbs: [
-        {
-          text: 'src',
-        },
-        {
-          text: 'components',
-        },
-      ],
-    },
-    {
-      controlType: 'spacer',
-    },
-    {
-      id: 'github_icon',
-      controlType: 'icon',
-      iconType: 'logoGithub',
-    },
-    {
-      id: 'github_text',
-      controlType: 'text',
-      label: 'Open in Github',
-    },
-  ]}/>`;
 
 const buttonPropsTable = [
   {
@@ -238,6 +156,14 @@ const iconPropsTable = [
   },
 ];
 
+const spacerAndDividerPropsTable = [
+  {
+    prop: 'id',
+    type: 'string',
+    description: 'Provide a unique id for the element.',
+  },
+];
+
 const tableColumns = [
   {
     field: 'prop',
@@ -281,14 +207,56 @@ export const ControlBarExample = {
             actions.
           </p>
           <p>
-            The control bar provides an easy way to extend the navigation or
-            views of the current page by allowing you to place tabs, buttons,
-            text, or <EuiCode>children</EuiCode> within it. It can operate
-            similarly to a flyout, but (at full height) it covers most of the
-            current page; making it a fitting solution for verbose text or
-            additional controls. It can also be used without allowing it to
-            expand, which makes it an easy way to display status information or
-            fixed-position buttons.
+            The <EuiCode>ControlBar</EuiCode> accepts an array of
+            <EuiCode>controlTypes</EuiCode> that can be arranged virtually any
+            way you&apos;d like by using any of following
+            <EuiCode>controlTypes</EuiCode>. The controlTypes will be ordered
+            the same way they are in the array you provide.
+          </p>
+          <h2>Mobile Usage</h2>
+          The <EuiCode>ControlBar</EuiCode> is responsive in the sense that it
+          utilizes flexbox. However, it makes no attempts to reorganize the
+          controls you provide. By default the <EuiCode>ControlBar</EuiCode> is
+          hidden on mobile devices, but this can be overridden with the
+          <EuiCode>showOnMobile</EuiCode> prop. You&apos;ll need to take smaller
+          screens into consideration when choosing to display on smaller
+          screens.
+          <h3>Button Control</h3>
+          <EuiBasicTable items={buttonPropsTable} columns={tableColumns} />
+          <h3>Tab Control</h3>
+          <EuiBasicTable items={tabPropsTable} columns={tableColumns} />
+          <h3>Breadcrumbs Control</h3>
+          <p>
+            View the documentation on <EuiCode>EuiBreadcrumbs</EuiCode> for
+            additional information on their usage.
+          </p>
+          <EuiBasicTable items={breadcrumbsPropsTable} columns={tableColumns} />
+          <h3>Text Control</h3>
+          <EuiBasicTable items={textPropsTable} columns={tableColumns} />
+          <h3>Icon Control</h3>
+          <EuiBasicTable items={iconPropsTable} columns={tableColumns} />
+          <h3>Spacer & Divider Control</h3>
+          <EuiBasicTable
+            items={spacerAndDividerPropsTable}
+            columns={tableColumns}
+          />
+          <h4>Spacers</h4>
+          <p>
+            Spacers can be used to provide horizontal spaces between your
+            <EuiCode>controlTypes</EuiCode>.
+          </p>
+          <h4>Dividers</h4>
+          <p>
+            Dividers provide <EuiCode>1px</EuiCode> wide colored breaks between
+            your <EuiCode>controlTypes</EuiCode>. Useful when additional visual
+            separation is needed.
+          </p>
+          <h3>Rendering content to the control bar drawer</h3>
+          <p>
+            Optional children of the <EuiCode>EuiControlBar</EuiCode> are
+            rendered in the control bar drawer. You can toggle the visibility of
+            the content with the <EuiCode>showContent</EuiCode> prop. When you
+            want to display tab content, this is where you&apos;ll do it.
           </p>
         </div>
       ),
@@ -319,89 +287,6 @@ export const ControlBarExample = {
       props: { EuiControlBar },
       snippet: tabsBarSnippet,
       demo: <ControlBarWithTabs />,
-    },
-    {
-      title: 'Mobile Usage',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: mobileBarSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: mobileBarHtml,
-        },
-      ],
-      text: (
-        <div>
-          <p>
-            The <EuiCode>ControlBar</EuiCode> is responsive in the sense that it
-            utilizes flexbox. However, it makes no attempts to reorganize the
-            controls you provide. By default the <EuiCode>ControlBar</EuiCode>{' '}
-            is hidden on mobile devices, but this can be overridden with the
-            <EuiCode>showOnMobile</EuiCode> prop. You&apos;ll need to take the
-            layout of your <EuiCode>controlTypes</EuiCode> into consideration
-            when choosing to display on smaller screens.
-          </p>
-          <p>
-            A simple way of doing this is to pass in EUI responsive utility
-            classes into the <EuiCode>className</EuiCode> prop on any of the{' '}
-            <EuiCode>controlTypes</EuiCode>. View the snippet tab to see an
-            example.
-          </p>
-        </div>
-      ),
-      props: { EuiControlBar },
-      snippet: mobileBarSnippet,
-      demo: <ControlBarMobile />,
-    },
-    {
-      title: 'ControlTypes',
-      text: (
-        <div>
-          <p>
-            The <EuiCode>ControlBar</EuiCode> accepts an array of
-            <EuiCode>controlTypes</EuiCode> that can be arranged virtually any
-            way you&apos;d like by using any of following
-            <EuiCode>controlTypes</EuiCode>. The controlTypes will be ordered
-            the same way they are in the array you provide.
-          </p>
-          <h3>Button Control</h3>
-          <EuiBasicTable items={buttonPropsTable} columns={tableColumns} />
-          <h3>Tab Control</h3>
-          <EuiBasicTable items={tabPropsTable} columns={tableColumns} />
-          <h3>Breadcrumbs Control</h3>
-          <p>
-            View the documentation on <EuiCode>EuiBreadcrumbs</EuiCode> for
-            additional information on their usage.
-          </p>
-          <EuiBasicTable items={breadcrumbsPropsTable} columns={tableColumns} />
-          <h3>Text Control</h3>
-          <EuiBasicTable items={textPropsTable} columns={tableColumns} />
-          <h3>Icon Control</h3>
-          <EuiBasicTable items={iconPropsTable} columns={tableColumns} />
-          <h3>Spacer & Divider Control</h3>
-          <h4>Spacers</h4>
-          <p>
-            Spacers can be used to provide horizontal spaces between your
-            <EuiCode>controlTypes</EuiCode>. Spacers do not need{' '}
-            <EuiCode>ids</EuiCode>.
-          </p>
-          <h4>Dividers</h4>
-          <p>
-            Dividers provide <EuiCode>1px</EuiCode> wide colored breaks between
-            your <EuiCode>controlTypes</EuiCode>. Useful when additional visual
-            separation is needed. Dividers do not need <EuiCode>ids</EuiCode>.
-          </p>
-          <h3>Rendering content to the control bar drawer</h3>
-          <p>
-            Optional children of the <EuiCode>EuiControlBar</EuiCode> are
-            rendered in the control bar drawer. You can toggle the visibility of
-            the content with the <EuiCode>showContent</EuiCode> prop. When you
-            want to display tab content, this is where you&apos;ll do it.
-          </p>
-        </div>
-      ),
     },
   ],
 };

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -204,10 +204,10 @@ export const ControlBarExample = {
             it utilizes flexbox and overflow scrolls. However, it makes no
             attempts to reorganize the controls you provide. By default the{' '}
             <EuiCode>EuiControlBar</EuiCode> is hidden on mobile devices, but
-            this can be overridden with the
-            <EuiCode>showOnMobile</EuiCode> prop. You&apos;ll need to take the
-            layout of your <EuiCode>controlTypes</EuiCode> into consideration
-            when choosing to display on smaller screens.
+            this can be overridden with the <EuiCode>showOnMobile</EuiCode>{' '}
+            prop. You&apos;ll need to take the layout of your{' '}
+            <EuiCode>controlTypes</EuiCode> into consideration when choosing to
+            display on smaller screens.
           </p>
           <p>
             A simple way of doing this is to pass in EUI responsive utility
@@ -236,7 +236,7 @@ export const ControlBarExample = {
       text: (
         <div>
           <p>
-            The <EuiCode>EuiControlBar</EuiCode> accepts an array of
+            The <EuiCode>EuiControlBar</EuiCode> accepts an array of{' '}
             <EuiCode>controlTypes</EuiCode> that will be arranged in the order
             in which they are provided. All controls <strong>must</strong> be
             provide a unique <EuiCode>id</EuiCode> to be used as the key.

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -1,17 +1,30 @@
 import React from 'react';
+import { Link } from 'react-router';
+
+import { EuiCode, EuiControlBar } from '../../../../src/components';
 
 import {
-  EuiBasicTable,
-  EuiCode,
-  EuiControlBar,
-} from '../../../../src/components';
+  BreadcrumbControlProps,
+  ButtonControlProps,
+  DividerControlProps,
+  IconControlTypeProps,
+  IconButtonControlTypeProps,
+  SpacerControlProps,
+  TabControlProps,
+  TextControlProps,
+} from './props';
 
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
 
 import ControlBar from './control_bar';
+import { Controls } from './controls';
 import { ControlBarWithTabs } from './tabs';
+import { ControlBarMobile } from './mobile';
+
+const controlsSource = require('!!raw-loader!./controls');
+const controlsHtml = renderToHtml(Controls);
 
 const controlBarSource = require('!!raw-loader!./control_bar');
 const controlBarHtml = renderToHtml(ControlBar);
@@ -60,169 +73,47 @@ const tabsBarSource = require('!!raw-loader!./tabs');
 const tabsBarHtml = renderToHtml(ControlBarWithTabs);
 const tabsBarSnippet = '<EuiControlBar controls={items} size="m"/>';
 
-const buttonPropsTable = [
-  {
-    prop: 'id',
-    type: 'string',
-    description: 'Provide a unique id for the element',
-  },
-  {
-    prop: 'color (optional)',
-    type: 'props of EuiButton["color"]',
-    description: 'Set the button color. Defaults to "ghost."',
-  },
-  {
-    prop: 'label',
-    type: 'string',
-    description: 'Displays the button label',
-  },
-  {
-    prop: 'classNames (optional)',
-    type: 'string',
-    description: 'Optionally pass additional classes.',
-  },
-  {
-    prop: 'onClick',
-    type: 'function',
-    description: 'Handle the click event',
-  },
-];
-
-const tabPropsTable = [
-  {
-    prop: 'id',
-    type: 'string',
-    description: 'Provide a unique id for the element',
-  },
-  {
-    prop: 'label',
-    type: 'string',
-    description: 'Displays the Tab label',
-  },
-  {
-    prop: 'onClick',
-    type: 'function',
-    description:
-      'Handle the tab click. Most likely this will be used to set ' +
-      'something like the active tab on your state.',
-  },
-];
-
-const breadcrumbsPropsTable = [
-  {
-    prop: 'id',
-    type: 'string',
-    description: 'Provide a unique id for the element',
-  },
-  {
-    prop: 'responsive (optional)',
-    type: 'boolean',
-    description: 'Hides left most breadcrumbs as window gets smaller',
-  },
-  {
-    prop: 'truncate (optional)',
-    type: 'boolean',
-    description:
-      'Forces all breadcrumbs to single line and' +
-      'truncates each breadcrumb to a particular width, except for the last item',
-  },
-  {
-    prop: 'max (optional)',
-    type: 'number',
-    description:
-      'Condenses the inner items past the maximum set into a single ellipses item',
-  },
-  {
-    prop: 'breadcrumbs',
-    type: 'array',
-    description: 'An array of items for the breadcrumbs',
-  },
-];
-
-const textPropsTable = [
-  {
-    prop: 'id',
-    type: 'string',
-    description: 'Provide a unique id for the element',
-  },
-  {
-    prop: 'label',
-    type: 'string',
-    description: 'Displays the Text label',
-  },
-  {
-    prop: 'color (optional)',
-    type: 'props of EuiText["color"]',
-    description: 'Sets the color of the text. Defaults to "ghost."',
-  },
-  {
-    prop: 'onClick (optional)',
-    type: 'function',
-    description: 'Handle the click event',
-  },
-];
-
-const iconPropsTable = [
-  {
-    prop: 'id',
-    type: 'string',
-    description: 'Provide a unique id for the element.',
-  },
-  {
-    prop: 'iconType',
-    type: 'string',
-    description: 'Which icon to render',
-  },
-  {
-    prop: 'label',
-    type: 'string',
-    description: 'For accessibility',
-  },
-  {
-    prop: 'classNames (optional)',
-    type: 'string',
-    description: 'Optionally pass additional classes.',
-  },
-  {
-    prop: 'color (optional)',
-    type: 'props of EuiButtonIcon["color"]',
-    description: 'Sets the color of the icon. Defaults to "ghost."',
-  },
-  {
-    prop: 'onClick (optional)',
-    type: 'function',
-    description: 'Handle the click event',
-  },
-];
-
-const spacerAndDividerPropsTable = [
-  {
-    prop: 'id',
-    type: 'string',
-    description: 'Provide a unique id for the element.',
-  },
-];
-
-const tableColumns = [
-  {
-    field: 'prop',
-    name: 'Prop',
-    sortable: false,
-    'data-test-subj': 'propCell',
-  },
-  {
-    field: 'type',
-    name: 'Type',
-    sortable: false,
-    'data-test-subj': 'typeCell',
-  },
-  {
-    field: 'description',
-    name: 'Description',
-    sortable: false,
-    'data-test-subj': 'descriptionCell',
-  },
-];
+const mobileBarSource = require('!!raw-loader!./mobile');
+const mobileBarHtml = renderToHtml(ControlBarMobile);
+const mobileBarSnippet = `<EuiControlBar
+  showOnMobile
+  controls={[
+    {
+      id: 'icon',
+      controlType: 'icon',
+      label: 'folder',
+      iconType: 'folderClosed',
+      className: 'eui-hideFor--m eui-hideFor--l eui-hideFor--xl',
+    },
+    {
+      id: 'current_file_path',
+      label: 'breadcrumbs',
+      controlType: 'breadcrumbs',
+      responsive: true,
+      className: 'eui-hideFor--s eui-hideFor--xs',
+      breadcrumbs: [
+        {
+          text: 'src',
+        },
+        {
+          text: 'components',
+        },
+      ],
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      id: 'github_icon',
+      controlType: 'icon',
+      iconType: 'logoGithub',
+    },
+    {
+      id: 'github_text',
+      controlType: 'text',
+      label: 'Open in Github',
+    },
+  ]}/>`;
 
 export const ControlBarExample = {
   title: 'Control Bar',
@@ -246,56 +137,14 @@ export const ControlBarExample = {
             actions.
           </p>
           <p>
-            The <EuiCode>ControlBar</EuiCode> accepts an array of
-            <EuiCode>controlTypes</EuiCode> that can be arranged virtually any
-            way you&apos;d like by using any of following
-            <EuiCode>controlTypes</EuiCode>. The controlTypes will be ordered
-            the same way they are in the array you provide.
-          </p>
-          <h2>Mobile Usage</h2>
-          The <EuiCode>ControlBar</EuiCode> is responsive in the sense that it
-          utilizes flexbox. However, it makes no attempts to reorganize the
-          controls you provide. By default the <EuiCode>ControlBar</EuiCode> is
-          hidden on mobile devices, but this can be overridden with the
-          <EuiCode>showOnMobile</EuiCode> prop. You&apos;ll need to take smaller
-          screens into consideration when choosing to display on smaller
-          screens.
-          <h3>Button Control</h3>
-          <EuiBasicTable items={buttonPropsTable} columns={tableColumns} />
-          <h3>Tab Control</h3>
-          <EuiBasicTable items={tabPropsTable} columns={tableColumns} />
-          <h3>Breadcrumbs Control</h3>
-          <p>
-            View the documentation on <EuiCode>EuiBreadcrumbs</EuiCode> for
-            additional information on their usage.
-          </p>
-          <EuiBasicTable items={breadcrumbsPropsTable} columns={tableColumns} />
-          <h3>Text Control</h3>
-          <EuiBasicTable items={textPropsTable} columns={tableColumns} />
-          <h3>Icon Control</h3>
-          <EuiBasicTable items={iconPropsTable} columns={tableColumns} />
-          <h3>Spacer & Divider Control</h3>
-          <EuiBasicTable
-            items={spacerAndDividerPropsTable}
-            columns={tableColumns}
-          />
-          <h4>Spacers</h4>
-          <p>
-            Spacers can be used to provide horizontal spaces between your
-            <EuiCode>controlTypes</EuiCode>.
-          </p>
-          <h4>Dividers</h4>
-          <p>
-            Dividers provide <EuiCode>1px</EuiCode> wide colored breaks between
-            your <EuiCode>controlTypes</EuiCode>. Useful when additional visual
-            separation is needed.
-          </p>
-          <h3>Rendering content to the control bar drawer</h3>
-          <p>
-            Optional children of the <EuiCode>EuiControlBar</EuiCode> are
-            rendered in the control bar drawer. You can toggle the visibility of
-            the content with the <EuiCode>showContent</EuiCode> prop. When you
-            want to display tab content, this is where you&apos;ll do it.
+            The control bar provides an easy way to extend the navigation or
+            views of the current page by allowing you to place tabs, buttons,
+            text, or <EuiCode>children</EuiCode> within it. It can operate
+            similarly to a flyout, but (at full height) it covers most of the
+            current page; making it a fitting solution for verbose text or
+            additional controls. It can also be used without allowing it to
+            expand, which makes it an easy way to display status information or
+            fixed-position buttons.
           </p>
         </div>
       ),
@@ -326,6 +175,116 @@ export const ControlBarExample = {
       props: { EuiControlBar },
       snippet: tabsBarSnippet,
       demo: <ControlBarWithTabs />,
+    },
+    {
+      title: 'Mobile Usage',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: mobileBarSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: mobileBarHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            The <EuiCode>ControlBar</EuiCode> is responsive in the sense that it
+            utilizes flexbox. However, it makes no attempts to reorganize the
+            controls you provide. By default the <EuiCode>ControlBar</EuiCode>{' '}
+            is hidden on mobile devices, but this can be overridden with the
+            <EuiCode>showOnMobile</EuiCode> prop. You&apos;ll need to take the
+            layout of your <EuiCode>controlTypes</EuiCode> into consideration
+            when choosing to display on smaller screens.
+          </p>
+          <p>
+            A simple way of doing this is to pass in EUI responsive utility
+            classes into the <EuiCode>className</EuiCode> prop on any of the{' '}
+            <EuiCode>controlTypes</EuiCode>. View the snippet tab to see an
+            example.
+          </p>
+        </div>
+      ),
+      props: { EuiControlBar },
+      snippet: mobileBarSnippet,
+      demo: <ControlBarMobile />,
+    },
+    {
+      title: 'Control Types',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: controlsSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: controlsHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            The <EuiCode>EuiControlBar</EuiCode> accepts an array of
+            <EuiCode>controlType</EuiCode>s that will be arranged in the order
+            in which they are provided. All controls <strong>must</strong> be
+            provide a unique <EuiCode>id</EuiCode> to be used as the key.
+          </p>
+          <ul>
+            <li>
+              <EuiCode>button</EuiCode>: Extends{' '}
+              <Link to="/navigation/button">EuiButton</Link> but always forces
+              to size small. Requires <EuiCode>label</EuiCode> as the children.
+            </li>
+            <li>
+              <EuiCode>icon</EuiCode>: Extends{' '}
+              <Link to="/display/icons">EuiIcon</Link> unless provided an{' '}
+              <EuiCode>onClick</EuiCode> or <EuiCode>href</EuiCode>, then it
+              will render an <Link to="/navigation/button">EuiButtonIcon</Link>.
+            </li>
+            <li>
+              <EuiCode>text</EuiCode>: Simple ghost colored text.
+            </li>
+            <li>
+              <EuiCode>tab</EuiCode>: Renders a button visually as a tab. You
+              must provide your own callback to swap the control bar contents
+              with <EuiCode>onClick</EuiCode>.
+            </li>
+            <li>
+              <EuiCode>breadcrumbs</EuiCode>: Extends{' '}
+              <Link to="/navigation/breadcrumbs">EuiBreadcrumbs</Link>.
+            </li>
+            <li>
+              <EuiCode>spacer</EuiCode>: Provides a horizontal space between
+              controls. <strong>Id is optional.</strong>
+            </li>
+            <li>
+              <EuiCode>divider</EuiCode>: Provides a <EuiCode>1px</EuiCode>{' '}
+              border between controls. Useful when additional visual separation
+              is needed. <strong>Id is optional.</strong>
+            </li>
+          </ul>
+          <p>
+            Optional children of the <EuiCode>EuiControlBar</EuiCode> are
+            rendered in the control bar drawer. You can toggle the visibility of
+            the content with the <EuiCode>showContent</EuiCode> prop. When you
+            want to display tab content, this is where you&apos;ll do it.
+          </p>
+        </div>
+      ),
+      props: {
+        EuiControlBar,
+        BreadcrumbControlProps,
+        ButtonControlProps,
+        DividerControlProps,
+        IconControlTypeProps,
+        IconButtonControlTypeProps,
+        SpacerControlProps,
+        TabControlProps,
+        TextControlProps,
+      },
+      demo: <Controls />,
     },
   ],
 };

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -132,8 +132,8 @@ export const ControlBarExample = {
       text: (
         <div>
           <p>
-            <EuiCode>ControlBar</EuiCode> is a bottom positioned container and
-            content well intended to provide additional view controls and
+            <EuiCode>EuiControlBar</EuiCode> is a bottom positioned container
+            and content well intended to provide additional view controls and
             actions.
           </p>
           <p>
@@ -167,8 +167,14 @@ export const ControlBarExample = {
       text: (
         <div>
           <p>
-            This example deomnstrates the use of tabs and uses the size
-            <EuiCode>size=&quot;m&quot;</EuiCode>.
+            This example demonstrates the use of tabs and reduces the size of
+            the content with <EuiCode>size=&quot;m&quot;</EuiCode>.
+          </p>
+          <p>
+            Optional children of the <EuiCode>EuiControlBar</EuiCode> are
+            rendered in the control bar drawer. You can toggle the visibility of
+            the content with the <EuiCode>showContent</EuiCode> prop. When you
+            want to display tab content, this is where you&apos;ll do it.
           </p>
         </div>
       ),
@@ -191,10 +197,11 @@ export const ControlBarExample = {
       text: (
         <div>
           <p>
-            The <EuiCode>ControlBar</EuiCode> is responsive in the sense that it
-            utilizes flexbox. However, it makes no attempts to reorganize the
-            controls you provide. By default the <EuiCode>ControlBar</EuiCode>{' '}
-            is hidden on mobile devices, but this can be overridden with the
+            The <EuiCode>EuiControlBar</EuiCode> is responsive in the sense that
+            it utilizes flexbox and overflow scrolls. However, it makes no
+            attempts to reorganize the controls you provide. By default the{' '}
+            <EuiCode>EuiControlBar</EuiCode> is hidden on mobile devices, but
+            this can be overridden with the
             <EuiCode>showOnMobile</EuiCode> prop. You&apos;ll need to take the
             layout of your <EuiCode>controlTypes</EuiCode> into consideration
             when choosing to display on smaller screens.
@@ -212,7 +219,7 @@ export const ControlBarExample = {
       demo: <ControlBarMobile />,
     },
     {
-      title: 'Control Types',
+      title: 'Control types and position',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -227,7 +234,7 @@ export const ControlBarExample = {
         <div>
           <p>
             The <EuiCode>EuiControlBar</EuiCode> accepts an array of
-            <EuiCode>controlType</EuiCode>s that will be arranged in the order
+            <EuiCode>controlTypes</EuiCode> that will be arranged in the order
             in which they are provided. All controls <strong>must</strong> be
             provide a unique <EuiCode>id</EuiCode> to be used as the key.
           </p>
@@ -266,10 +273,17 @@ export const ControlBarExample = {
             </li>
           </ul>
           <p>
-            Optional children of the <EuiCode>EuiControlBar</EuiCode> are
-            rendered in the control bar drawer. You can toggle the visibility of
-            the content with the <EuiCode>showContent</EuiCode> prop. When you
-            want to display tab content, this is where you&apos;ll do it.
+            Typically, a control bar is fixed positioned against the browser
+            window and therefore rendered within a portal. To change the parent
+            element of the control bar, change the <EuiCode>position</EuiCode>{' '}
+            prop to <EuiCode>&apos;absolute&apos;</EuiCode> or{' '}
+            <EuiCode>&apos;relative&apos;</EuiCode>.
+          </p>
+          <p>
+            To offest the left and right position of the control bar, for
+            example, to adjust for side navigation, use the{' '}
+            <EuiCode>leftOffset</EuiCode> or <EuiCode>rightOffset</EuiCode>{' '}
+            props.
           </p>
         </div>
       ),

--- a/src-docs/src/views/control_bar/controls.js
+++ b/src-docs/src/views/control_bar/controls.js
@@ -1,58 +1,13 @@
 import React from 'react';
 
-import {
-  EuiButton,
-  EuiControlBar,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-} from '../../../../src/components';
-import { keyCodes } from '../../../../src/services';
-import { EuiFocusTrap } from '../../../../src/components/focus_trap';
-
+import { EuiControlBar, EuiLink } from '../../../../src/components';
 export class Controls extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      contentIsVisible: true,
-      isFullScreen: true,
-      tabContent: '',
-    };
   }
 
   soundTheAlarms = () => {
     alert('You clicked a button!');
-  };
-
-  tabOne = () => {
-    this.setState({
-      contentIsVisible: true,
-      tabContent: 'Tab content',
-    });
-  };
-
-  toggle() {
-    this.setState({
-      contentIsVisible: !this.state.contentIsVisible,
-    });
-  }
-
-  toggleFullScreen() {
-    this.setState(prevState => ({
-      isFullScreen: !prevState.isFullScreen,
-      contentIsVisible: false,
-    }));
-  }
-
-  onKeyDown = event => {
-    if (event.keyCode === keyCodes.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.setState({
-        isFullScreen: false,
-        contentIsVisible: false,
-      });
-    }
   };
 
   render() {
@@ -87,7 +42,7 @@ export class Controls extends React.Component {
       {
         controlType: 'text',
         id: 'controls_text',
-        label: 'Some text',
+        text: 'Some text',
       },
       {
         controlType: 'divider',
@@ -96,7 +51,15 @@ export class Controls extends React.Component {
         controlType: 'tab',
         id: 'controls_tab',
         label: 'Tab',
-        onClick: this.tabOne,
+        onClick: () => {},
+      },
+      {
+        controlType: 'divider',
+      },
+      {
+        controlType: 'text',
+        id: 'some_text',
+        text: <EuiLink>A sample link</EuiLink>,
       },
       {
         controlType: 'spacer',
@@ -115,46 +78,8 @@ export class Controls extends React.Component {
       },
     ];
 
-    let fullScreenDisplay;
-
-    if (this.state.isFullScreen) {
-      fullScreenDisplay = (
-        <EuiFocusTrap>
-          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
-            <EuiFlexGroup>
-              <EuiButton onClick={this.toggle.bind(this)}>
-                Toggle content drawer
-              </EuiButton>
-              <EuiFlexItem grow />
-              <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-                Close full screen
-              </EuiButton>
-            </EuiFlexGroup>
-            <EuiControlBar
-              controls={controls}
-              size="m"
-              showContent={this.state.contentIsVisible}
-              showOnMobile>
-              <div style={{ padding: '1rem' }}>
-                {this.state.tabContent !== '' ? (
-                  <EuiText>{this.state.tabContent}</EuiText>
-                ) : (
-                  <p>Look at me</p>
-                )}
-              </div>
-            </EuiControlBar>
-          </div>
-        </EuiFocusTrap>
-      );
-    }
-
     return (
-      <div>
-        <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-          View in full screen
-        </EuiButton>
-        {fullScreenDisplay}
-      </div>
+      <EuiControlBar controls={controls} position="relative" showOnMobile />
     );
   }
 }

--- a/src-docs/src/views/control_bar/controls.js
+++ b/src-docs/src/views/control_bar/controls.js
@@ -1,0 +1,160 @@
+import React from 'react';
+
+import {
+  EuiButton,
+  EuiControlBar,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+} from '../../../../src/components';
+import { keyCodes } from '../../../../src/services';
+import { EuiFocusTrap } from '../../../../src/components/focus_trap';
+
+export class Controls extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      contentIsVisible: true,
+      isFullScreen: true,
+      tabContent: '',
+    };
+  }
+
+  soundTheAlarms = () => {
+    alert('You clicked a button!');
+  };
+
+  tabOne = () => {
+    this.setState({
+      contentIsVisible: true,
+      tabContent: 'Tab content',
+    });
+  };
+
+  toggle() {
+    this.setState({
+      contentIsVisible: !this.state.contentIsVisible,
+    });
+  }
+
+  toggleFullScreen() {
+    this.setState(prevState => ({
+      isFullScreen: !prevState.isFullScreen,
+      contentIsVisible: false,
+    }));
+  }
+
+  onKeyDown = event => {
+    if (event.keyCode === keyCodes.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.setState({
+        isFullScreen: false,
+        contentIsVisible: false,
+      });
+    }
+  };
+
+  render() {
+    const controls = [
+      {
+        controlType: 'button',
+        id: 'controls_button',
+        label: 'Button',
+        onClick: this.soundTheAlarms,
+      },
+      {
+        controlType: 'spacer',
+      },
+      {
+        controlType: 'icon',
+        id: 'controls_icon',
+        iconType: 'flag',
+      },
+      {
+        controlType: 'divider',
+      },
+      {
+        controlType: 'icon',
+        id: 'controls_icon_button',
+        iconType: 'bell',
+        onClick: this.soundTheAlarms,
+        color: 'primary',
+      },
+      {
+        controlType: 'divider',
+      },
+      {
+        controlType: 'text',
+        id: 'controls_text',
+        label: 'Some text',
+      },
+      {
+        controlType: 'divider',
+      },
+      {
+        controlType: 'tab',
+        id: 'controls_tab',
+        label: 'Tab',
+        onClick: this.tabOne,
+      },
+      {
+        controlType: 'spacer',
+      },
+      {
+        controlType: 'breadcrumbs',
+        id: 'controls_breadcrumbs',
+        breadcrumbs: [
+          {
+            text: 'Breadcrumbs',
+          },
+          {
+            text: 'Item',
+          },
+        ],
+      },
+    ];
+
+    let fullScreenDisplay;
+
+    if (this.state.isFullScreen) {
+      fullScreenDisplay = (
+        <EuiFocusTrap>
+          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
+            <EuiFlexGroup>
+              <EuiButton onClick={this.toggle.bind(this)}>
+                Toggle content drawer
+              </EuiButton>
+              <EuiFlexItem grow />
+              <EuiButton onClick={this.toggleFullScreen.bind(this)}>
+                Close full screen
+              </EuiButton>
+            </EuiFlexGroup>
+            <EuiControlBar
+              controls={controls}
+              size="m"
+              showContent={this.state.contentIsVisible}
+              showOnMobile>
+              <div style={{ padding: '1rem' }}>
+                {this.state.tabContent !== '' ? (
+                  <EuiText>{this.state.tabContent}</EuiText>
+                ) : (
+                  <p>Look at me</p>
+                )}
+              </div>
+            </EuiControlBar>
+          </div>
+        </EuiFocusTrap>
+      );
+    }
+
+    return (
+      <div>
+        <EuiButton onClick={this.toggleFullScreen.bind(this)}>
+          View in full screen
+        </EuiButton>
+        {fullScreenDisplay}
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/control_bar/controls.js
+++ b/src-docs/src/views/control_bar/controls.js
@@ -35,6 +35,7 @@ export class Controls extends React.Component {
         iconType: 'bell',
         onClick: this.soundTheAlarms,
         color: 'primary',
+        'aria-label': 'Bell',
       },
       {
         controlType: 'divider',

--- a/src-docs/src/views/control_bar/mobile.js
+++ b/src-docs/src/views/control_bar/mobile.js
@@ -1,60 +1,34 @@
 import React from 'react';
 
-import {
-  EuiButton,
-  EuiControlBar,
-  EuiFlexGroup,
-} from '../../../../src/components';
-import { keyCodes } from '../../../../src/services';
-import { EuiFocusTrap } from '../../../../src/components/focus_trap';
+import { EuiButton, EuiControlBar } from '../../../../src/components';
 
 export class ControlBarMobile extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      contentIsVisible: false,
-      isFullScreen: false,
+      isDisplaying: false,
       tabContent: '',
     };
   }
 
-  toggle() {
-    this.setState({
-      contentIsVisible: !this.state.contentIsVisible,
-    });
-  }
-
-  toggleFullScreen() {
+  toggleDisplay = () => {
     this.setState(prevState => ({
-      isFullScreen: !prevState.isFullScreen,
-      contentIsVisible: false,
+      isDisplaying: !prevState.isDisplaying,
     }));
-  }
-
-  onKeyDown = event => {
-    if (event.keyCode === keyCodes.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.setState({
-        isFullScreen: false,
-        contentIsVisible: false,
-      });
-    }
   };
 
   render() {
     const controls = [
       {
-        id: 'icon',
         controlType: 'icon',
-        label: 'folder',
+        id: 'icon',
         iconType: 'folderClosed',
+        'aria-label': 'folder',
         className: 'eui-hideFor--m eui-hideFor--l eui-hideFor--xl',
       },
       {
-        id: 'current_file_path',
-        label: 'breadcrumbs',
         controlType: 'breadcrumbs',
+        id: 'current_file_path',
         responsive: true,
         className: 'eui-hideFor--s eui-hideFor--xs',
         breadcrumbs: [
@@ -70,44 +44,30 @@ export class ControlBarMobile extends React.Component {
         controlType: 'spacer',
       },
       {
-        id: 'github_icon',
         controlType: 'icon',
+        id: 'github_icon',
         iconType: 'logoGithub',
+        'aria-label': 'Github',
       },
       {
-        id: 'github_text',
         controlType: 'text',
-        label: 'Open in Github',
+        id: 'github_text',
+        text: 'Open in Github',
       },
     ];
 
-    let fullScreenDisplay;
+    let display;
 
-    if (this.state.isFullScreen) {
-      fullScreenDisplay = (
-        <EuiFocusTrap>
-          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
-            <EuiFlexGroup>
-              <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-                Close
-              </EuiButton>
-            </EuiFlexGroup>
-            <EuiControlBar
-              controls={controls}
-              showContent={this.state.contentIsVisible}
-              showOnMobile
-            />
-          </div>
-        </EuiFocusTrap>
-      );
+    if (this.state.isDisplaying) {
+      display = <EuiControlBar controls={controls} showOnMobile />;
     }
 
     return (
       <div>
-        <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-          View mobile example
+        <EuiButton onClick={this.toggleDisplay}>
+          Toggle mobile example
         </EuiButton>
-        {fullScreenDisplay}
+        {display}
       </div>
     );
   }

--- a/src-docs/src/views/control_bar/props.tsx
+++ b/src-docs/src/views/control_bar/props.tsx
@@ -1,0 +1,39 @@
+import React, { FunctionComponent } from 'react';
+
+import {
+  BreadcrumbControl,
+  ButtonControl,
+  DividerControl,
+  IconControlType,
+  IconButtonControlType,
+  SpacerControl,
+  TabControl,
+  TextControl,
+} from '../../../../src/components/control_bar/control_bar';
+
+export const BreadcrumbControlProps: FunctionComponent<
+  BreadcrumbControl
+> = () => <div />;
+
+export const ButtonControlProps: FunctionComponent<ButtonControl> = () => (
+  <div />
+);
+
+export const DividerControlProps: FunctionComponent<DividerControl> = () => (
+  <div />
+);
+
+export const IconControlTypeProps: FunctionComponent<IconControlType> = () => (
+  <div />
+);
+export const IconButtonControlTypeProps: FunctionComponent<
+  IconButtonControlType
+> = () => <div />;
+
+export const SpacerControlProps: FunctionComponent<SpacerControl> = () => (
+  <div />
+);
+
+export const TabControlProps: FunctionComponent<TabControl> = () => <div />;
+
+export const TextControlProps: FunctionComponent<TextControl> = () => <div />;

--- a/src-docs/src/views/control_bar/tabs.js
+++ b/src-docs/src/views/control_bar/tabs.js
@@ -72,7 +72,7 @@ export class ControlBarWithTabs extends React.Component {
   };
 
   render() {
-    const textLink = <EuiLink href="#">A sample link</EuiLink>;
+    const textLink = <EuiLink href="#">src / component / roller.tsx</EuiLink>;
 
     const controls = [
       {
@@ -93,8 +93,6 @@ export class ControlBarWithTabs extends React.Component {
         controlType: 'button',
         onClick: this.soundTheAlarms,
         color: 'danger',
-        'data-test-sub': 'look',
-        'aria-label': 'this is an aria label',
       },
       {
         id: 'close_the_hatch',
@@ -105,6 +103,7 @@ export class ControlBarWithTabs extends React.Component {
         color: 'primary',
       },
       {
+        id: 'spacer_in_tabs',
         controlType: 'spacer',
       },
       {
@@ -127,7 +126,13 @@ export class ControlBarWithTabs extends React.Component {
     if (this.state.isFullScreen) {
       fullScreenDisplay = (
         <EuiFocusTrap>
-          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
+          <div
+            className="guideDemo__pageOverlay"
+            style={{
+              padding: '2rem',
+              zIndex: '20000',
+            }}
+            onKeyDown={this.onKeyDown}>
             <EuiFlexGroup>
               <EuiButton onClick={this.toggle.bind(this)}>
                 Toggle Content Drawer
@@ -140,8 +145,7 @@ export class ControlBarWithTabs extends React.Component {
             <EuiControlBar
               controls={controls}
               size="m"
-              showContent={this.state.contentIsVisible}
-              showOnMobile>
+              showContent={this.state.contentIsVisible}>
               <div style={{ padding: '1rem' }}>
                 {this.state.tabContent !== '' ? (
                   <EuiText>{this.state.tabContent}</EuiText>

--- a/src-docs/src/views/control_bar/tabs.js
+++ b/src-docs/src/views/control_bar/tabs.js
@@ -126,13 +126,7 @@ export class ControlBarWithTabs extends React.Component {
     if (this.state.isFullScreen) {
       fullScreenDisplay = (
         <EuiFocusTrap>
-          <div
-            className="guideDemo__pageOverlay"
-            style={{
-              padding: '2rem',
-              zIndex: '20000',
-            }}
-            onKeyDown={this.onKeyDown}>
+          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
             <EuiFlexGroup>
               <EuiButton onClick={this.toggle.bind(this)}>
                 Toggle Content Drawer

--- a/src-docs/src/views/control_bar/tabs.js
+++ b/src-docs/src/views/control_bar/tabs.js
@@ -1,22 +1,13 @@
 import React from 'react';
 
-import {
-  EuiButton,
-  EuiControlBar,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLink,
-  EuiText,
-} from '../../../../src/components';
-import { keyCodes } from '../../../../src/services';
-import { EuiFocusTrap } from '../../../../src/components/focus_trap';
+import { EuiButton, EuiControlBar, EuiText } from '../../../../src/components';
 
 export class ControlBarWithTabs extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       contentIsVisible: false,
-      isFullScreen: false,
+      isDisplaying: false,
       tabContent: '',
     };
   }
@@ -47,118 +38,78 @@ export class ControlBarWithTabs extends React.Component {
     });
   };
 
-  toggle() {
-    this.setState({
-      contentIsVisible: !this.state.contentIsVisible,
-    });
-  }
-
-  toggleFullScreen() {
+  toggleDisplay = () => {
     this.setState(prevState => ({
-      isFullScreen: !prevState.isFullScreen,
+      isDisplaying: !prevState.isDisplaying,
       contentIsVisible: false,
     }));
-  }
-
-  onKeyDown = event => {
-    if (event.keyCode === keyCodes.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.setState({
-        isFullScreen: false,
-        contentIsVisible: false,
-      });
-    }
   };
 
   render() {
-    const textLink = <EuiLink href="#">src / component / roller.tsx</EuiLink>;
-
     const controls = [
       {
+        controlType: 'tab',
         id: 'flight_815',
         label: 'Flight 815',
-        controlType: 'tab',
         onClick: this.tabOne,
       },
       {
+        controlType: 'tab',
         id: 'the_others',
         label: 'The Others',
-        controlType: 'tab',
         onClick: this.tabTwo,
       },
       {
+        controlType: 'button',
         id: 'sound_the_alarm',
         label: 'Sound the Alarm',
-        controlType: 'button',
         onClick: this.soundTheAlarms,
         color: 'danger',
+        iconType: 'bell',
+        'data-test-subj': 'look',
       },
       {
+        controlType: 'button',
         id: 'close_the_hatch',
         label: 'Close the Hatch',
-        controlType: 'button',
         onClick: this.closeTheHatch,
-        classNames: 'customClassName',
+        className: 'customClassName',
         color: 'primary',
       },
       {
-        id: 'spacer_in_tabs',
         controlType: 'spacer',
       },
       {
-        id: 'set_the_timer',
-        label: 'Set the Timer',
         controlType: 'icon',
+        id: 'set_the_timer',
         iconType: 'clock',
         onClick: this.closeTheHatch,
-      },
-      {
-        id: 'some_text',
-        label: textLink,
-        controlType: 'text',
-        onClick: null,
+        'aria-label': 'Set the Timer',
       },
     ];
 
-    let fullScreenDisplay;
+    let display;
 
-    if (this.state.isFullScreen) {
-      fullScreenDisplay = (
-        <EuiFocusTrap>
-          <div className="guideDemo__pageOverlay" onKeyDown={this.onKeyDown}>
-            <EuiFlexGroup>
-              <EuiButton onClick={this.toggle.bind(this)}>
-                Toggle Content Drawer
-              </EuiButton>
-              <EuiFlexItem grow />
-              <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-                Close
-              </EuiButton>
-            </EuiFlexGroup>
-            <EuiControlBar
-              controls={controls}
-              size="m"
-              showContent={this.state.contentIsVisible}>
-              <div style={{ padding: '1rem' }}>
-                {this.state.tabContent !== '' ? (
-                  <EuiText>{this.state.tabContent}</EuiText>
-                ) : (
-                  <p>Look at me</p>
-                )}
-              </div>
-            </EuiControlBar>
-          </div>
-        </EuiFocusTrap>
+    if (this.state.isDisplaying) {
+      display = (
+        <EuiControlBar
+          controls={controls}
+          size="m"
+          showContent={this.state.contentIsVisible}
+          showOnMobile>
+          {this.state.tabContent !== '' && (
+            <div style={{ padding: '1rem' }}>
+              <EuiText>{this.state.tabContent}</EuiText>
+            </div>
+          )}
+        </EuiControlBar>
       );
     }
 
     return (
       <div>
-        <EuiButton onClick={this.toggleFullScreen.bind(this)}>
-          View in Full Screen
-        </EuiButton>
-        {fullScreenDisplay}
+        <EuiButton onClick={this.toggleDisplay}>Toggle tabs example</EuiButton>
+        {display}
       </div>
     );
   }

--- a/src/components/button/_variables.scss
+++ b/src/components/button/_variables.scss
@@ -5,7 +5,7 @@ $euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 70%);
 $euiButtonToggleBorderColor: $euiColorLightShade;
 
 // Modifier naming and colors.
-$buttonTypes: (
+$euiButtonTypes: (
   primary: $euiColorPrimary,
   secondary: $euiColorSecondary,
   warning: $euiColorWarning,

--- a/src/components/button/_variables.scss
+++ b/src/components/button/_variables.scss
@@ -5,7 +5,7 @@ $euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 70%);
 $euiButtonToggleBorderColor: $euiColorLightShade;
 
 // Modifier naming and colors.
-$euiButtonTypes: (
+$buttonTypes: (
   primary: $euiColorPrimary,
   secondary: $euiColorSecondary,
   warning: $euiColorWarning,

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -34,58 +34,1571 @@ exports[`EuiControlBar is rendered 1`] = `
     </nav>
     <div
       class="euiControlBar__text"
-      data-test-subj="dts"
     >
       Close the Hatch
     </div>
     <div
+      class="euiControlBar__divider"
+    />
+    <svg
+      aria-label="Sample Icon"
+      class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <div
       class="euiControlBar__spacer"
     />
+    <button
+      class="euiControlBar__tab"
+    >
+      Flight 815
+    </button>
   </div>
 </div>
 `;
 
-exports[`mobile control bar is rendered 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiControlBar testClass1 testClass2 euiControlBar--large euiControlBar--fixed euiControlBar--showOnMobile"
-  data-test-subj="test subject string"
-  style="left: 0px; right: 0px;"
+exports[`EuiControlBar props leftOffset is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={200}
+  position="fixed"
+  rightOffset={0}
+  showContent={false}
+  showOnMobile={false}
+  size="l"
+>
+  <EuiPortal>
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="euiControlBar euiControlBar--large euiControlBar--fixed"
+            style="left: 200px; right: 0px;"
+          >
+            <div
+              class="euiControlBar__controls"
+            >
+              <nav
+                aria-label="breadcrumb"
+                class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+              >
+                <button
+                  class="euiLink euiLink--subdued euiBreadcrumb"
+                  title="src"
+                  type="button"
+                >
+                  src
+                </button>
+                <div
+                  class="euiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </nav>
+              <div
+                class="euiControlBar__text"
+              >
+                Close the Hatch
+              </div>
+              <div
+                class="euiControlBar__divider"
+              />
+              <svg
+                aria-label="Sample Icon"
+                class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="euiControlBar__spacer"
+              />
+              <button
+                class="euiControlBar__tab"
+              >
+                Flight 815
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div
+        className="euiControlBar euiControlBar--large euiControlBar--fixed"
+        style={
+          Object {
+            "left": 200,
+            "maxHeight": undefined,
+            "right": 0,
+          }
+        }
+      >
+        <div
+          className="euiControlBar__controls"
+        >
+          <EuiBreadcrumbs
+            breadcrumbs={
+              Array [
+                Object {
+                  "text": "src",
+                },
+                Object {
+                  "text": "components",
+                },
+              ]
+            }
+            key="current_file_path"
+            responsive={true}
+          >
+            <nav
+              aria-label="breadcrumb"
+              className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+            >
+              <EuiInnerText>
+                <EuiLink
+                  className="euiBreadcrumb"
+                  color="subdued"
+                  title="src"
+                >
+                  <button
+                    className="euiLink euiLink--subdued euiBreadcrumb"
+                    title="src"
+                    type="button"
+                  >
+                    src
+                  </button>
+                </EuiLink>
+              </EuiInnerText>
+              <EuiBreadcrumbSeparator>
+                <div
+                  className="euiBreadcrumbSeparator"
+                />
+              </EuiBreadcrumbSeparator>
+              <EuiInnerText>
+                <span
+                  aria-current="page"
+                  className="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </EuiInnerText>
+            </nav>
+          </EuiBreadcrumbs>
+          <div
+            className="euiControlBar__text"
+            key="close_the_hatch"
+          >
+            Close the Hatch
+          </div>
+          <div
+            className="euiControlBar__divider"
+            key="divider2"
+          />
+          <EuiIcon
+            aria-label="Sample Icon"
+            className="euiControlBar__icon"
+            color="danger"
+            key="sample_icon3"
+            type="alert"
+          >
+            <EuiIconEmpty
+              aria-label="Sample Icon"
+              className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+              focusable="false"
+              style={null}
+            >
+              <svg
+                aria-label="Sample Icon"
+                className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </EuiIconEmpty>
+          </EuiIcon>
+          <div
+            className="euiControlBar__spacer"
+            key="spacer4"
+          />
+          <button
+            className="euiControlBar__tab"
+            key="flight_8155"
+            onClick={[Function]}
+          >
+            Flight 815
+          </button>
+        </div>
+      </div>
+    </Portal>
+  </EuiPortal>
+</EuiControlBar>
+`;
+
+exports[`EuiControlBar props maxHeight is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={0}
+  maxHeight="20rem"
+  position="fixed"
+  rightOffset={0}
+  showContent={false}
+  showOnMobile={false}
+  size="l"
+>
+  <EuiPortal>
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="euiControlBar euiControlBar--large euiControlBar--fixed"
+            style="left: 0px; right: 0px; max-height: 20rem;"
+          >
+            <div
+              class="euiControlBar__controls"
+            >
+              <nav
+                aria-label="breadcrumb"
+                class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+              >
+                <button
+                  class="euiLink euiLink--subdued euiBreadcrumb"
+                  title="src"
+                  type="button"
+                >
+                  src
+                </button>
+                <div
+                  class="euiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </nav>
+              <div
+                class="euiControlBar__text"
+              >
+                Close the Hatch
+              </div>
+              <div
+                class="euiControlBar__divider"
+              />
+              <svg
+                aria-label="Sample Icon"
+                class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="euiControlBar__spacer"
+              />
+              <button
+                class="euiControlBar__tab"
+              >
+                Flight 815
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div
+        className="euiControlBar euiControlBar--large euiControlBar--fixed"
+        style={
+          Object {
+            "left": 0,
+            "maxHeight": "20rem",
+            "right": 0,
+          }
+        }
+      >
+        <div
+          className="euiControlBar__controls"
+        >
+          <EuiBreadcrumbs
+            breadcrumbs={
+              Array [
+                Object {
+                  "text": "src",
+                },
+                Object {
+                  "text": "components",
+                },
+              ]
+            }
+            key="current_file_path"
+            responsive={true}
+          >
+            <nav
+              aria-label="breadcrumb"
+              className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+            >
+              <EuiInnerText>
+                <EuiLink
+                  className="euiBreadcrumb"
+                  color="subdued"
+                  title="src"
+                >
+                  <button
+                    className="euiLink euiLink--subdued euiBreadcrumb"
+                    title="src"
+                    type="button"
+                  >
+                    src
+                  </button>
+                </EuiLink>
+              </EuiInnerText>
+              <EuiBreadcrumbSeparator>
+                <div
+                  className="euiBreadcrumbSeparator"
+                />
+              </EuiBreadcrumbSeparator>
+              <EuiInnerText>
+                <span
+                  aria-current="page"
+                  className="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </EuiInnerText>
+            </nav>
+          </EuiBreadcrumbs>
+          <div
+            className="euiControlBar__text"
+            key="close_the_hatch"
+          >
+            Close the Hatch
+          </div>
+          <div
+            className="euiControlBar__divider"
+            key="divider2"
+          />
+          <EuiIcon
+            aria-label="Sample Icon"
+            className="euiControlBar__icon"
+            color="danger"
+            key="sample_icon3"
+            type="alert"
+          >
+            <EuiIconEmpty
+              aria-label="Sample Icon"
+              className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+              focusable="false"
+              style={null}
+            >
+              <svg
+                aria-label="Sample Icon"
+                className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </EuiIconEmpty>
+          </EuiIcon>
+          <div
+            className="euiControlBar__spacer"
+            key="spacer4"
+          />
+          <button
+            className="euiControlBar__tab"
+            key="flight_8155"
+            onClick={[Function]}
+          >
+            Flight 815
+          </button>
+        </div>
+      </div>
+    </Portal>
+  </EuiPortal>
+</EuiControlBar>
+`;
+
+exports[`EuiControlBar props mobile is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={0}
+  position="fixed"
+  rightOffset={0}
+  showContent={false}
+  showOnMobile={true}
+  size="l"
+>
+  <EuiPortal>
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="euiControlBar euiControlBar--large euiControlBar--fixed euiControlBar--showOnMobile"
+            style="left: 0px; right: 0px;"
+          >
+            <div
+              class="euiControlBar__controls"
+            >
+              <nav
+                aria-label="breadcrumb"
+                class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+              >
+                <button
+                  class="euiLink euiLink--subdued euiBreadcrumb"
+                  title="src"
+                  type="button"
+                >
+                  src
+                </button>
+                <div
+                  class="euiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </nav>
+              <div
+                class="euiControlBar__text"
+              >
+                Close the Hatch
+              </div>
+              <div
+                class="euiControlBar__divider"
+              />
+              <svg
+                aria-label="Sample Icon"
+                class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="euiControlBar__spacer"
+              />
+              <button
+                class="euiControlBar__tab"
+              >
+                Flight 815
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div
+        className="euiControlBar euiControlBar--large euiControlBar--fixed euiControlBar--showOnMobile"
+        style={
+          Object {
+            "left": 0,
+            "maxHeight": undefined,
+            "right": 0,
+          }
+        }
+      >
+        <div
+          className="euiControlBar__controls"
+        >
+          <EuiBreadcrumbs
+            breadcrumbs={
+              Array [
+                Object {
+                  "text": "src",
+                },
+                Object {
+                  "text": "components",
+                },
+              ]
+            }
+            key="current_file_path"
+            responsive={true}
+          >
+            <nav
+              aria-label="breadcrumb"
+              className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+            >
+              <EuiInnerText>
+                <EuiLink
+                  className="euiBreadcrumb"
+                  color="subdued"
+                  title="src"
+                >
+                  <button
+                    className="euiLink euiLink--subdued euiBreadcrumb"
+                    title="src"
+                    type="button"
+                  >
+                    src
+                  </button>
+                </EuiLink>
+              </EuiInnerText>
+              <EuiBreadcrumbSeparator>
+                <div
+                  className="euiBreadcrumbSeparator"
+                />
+              </EuiBreadcrumbSeparator>
+              <EuiInnerText>
+                <span
+                  aria-current="page"
+                  className="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </EuiInnerText>
+            </nav>
+          </EuiBreadcrumbs>
+          <div
+            className="euiControlBar__text"
+            key="close_the_hatch"
+          >
+            Close the Hatch
+          </div>
+          <div
+            className="euiControlBar__divider"
+            key="divider2"
+          />
+          <EuiIcon
+            aria-label="Sample Icon"
+            className="euiControlBar__icon"
+            color="danger"
+            key="sample_icon3"
+            type="alert"
+          >
+            <EuiIconEmpty
+              aria-label="Sample Icon"
+              className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+              focusable="false"
+              style={null}
+            >
+              <svg
+                aria-label="Sample Icon"
+                className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </EuiIconEmpty>
+          </EuiIcon>
+          <div
+            className="euiControlBar__spacer"
+            key="spacer4"
+          />
+          <button
+            className="euiControlBar__tab"
+            key="flight_8155"
+            onClick={[Function]}
+          >
+            Flight 815
+          </button>
+        </div>
+      </div>
+    </Portal>
+  </EuiPortal>
+</EuiControlBar>
+`;
+
+exports[`EuiControlBar props position is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={0}
+  position="absolute"
+  rightOffset={0}
+  showContent={false}
+  showOnMobile={false}
+  size="l"
 >
   <div
-    class="euiControlBar__controls"
+    className="euiControlBar euiControlBar--large euiControlBar--absolute"
+    style={
+      Object {
+        "left": 0,
+        "maxHeight": undefined,
+        "right": 0,
+      }
+    }
   >
-    <nav
-      aria-label="breadcrumb"
-      class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+    <div
+      className="euiControlBar__controls"
     >
-      <button
-        class="euiLink euiLink--subdued euiBreadcrumb"
-        title="src"
-        type="button"
+      <EuiBreadcrumbs
+        breadcrumbs={
+          Array [
+            Object {
+              "text": "src",
+            },
+            Object {
+              "text": "components",
+            },
+          ]
+        }
+        key="current_file_path"
+        responsive={true}
       >
-        src
-      </button>
+        <nav
+          aria-label="breadcrumb"
+          className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+        >
+          <EuiInnerText>
+            <EuiLink
+              className="euiBreadcrumb"
+              color="subdued"
+              title="src"
+            >
+              <button
+                className="euiLink euiLink--subdued euiBreadcrumb"
+                title="src"
+                type="button"
+              >
+                src
+              </button>
+            </EuiLink>
+          </EuiInnerText>
+          <EuiBreadcrumbSeparator>
+            <div
+              className="euiBreadcrumbSeparator"
+            />
+          </EuiBreadcrumbSeparator>
+          <EuiInnerText>
+            <span
+              aria-current="page"
+              className="euiBreadcrumb euiBreadcrumb--last"
+              title="components"
+            >
+              components
+            </span>
+          </EuiInnerText>
+        </nav>
+      </EuiBreadcrumbs>
       <div
-        class="euiBreadcrumbSeparator"
-      />
-      <span
-        aria-current="page"
-        class="euiBreadcrumb euiBreadcrumb--last"
-        title="components"
+        className="euiControlBar__text"
+        key="close_the_hatch"
       >
-        components
-      </span>
-    </nav>
-    <div
-      class="euiControlBar__text"
-      data-test-subj="dts"
-    >
-      Close the Hatch
+        Close the Hatch
+      </div>
+      <div
+        className="euiControlBar__divider"
+        key="divider2"
+      />
+      <EuiIcon
+        aria-label="Sample Icon"
+        className="euiControlBar__icon"
+        color="danger"
+        key="sample_icon3"
+        type="alert"
+      >
+        <EuiIconEmpty
+          aria-label="Sample Icon"
+          className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+          focusable="false"
+          style={null}
+        >
+          <svg
+            aria-label="Sample Icon"
+            className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+            focusable="false"
+            height={16}
+            style={null}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </EuiIconEmpty>
+      </EuiIcon>
+      <div
+        className="euiControlBar__spacer"
+        key="spacer4"
+      />
+      <button
+        className="euiControlBar__tab"
+        key="flight_8155"
+        onClick={[Function]}
+      >
+        Flight 815
+      </button>
     </div>
-    <div
-      class="euiControlBar__spacer"
-    />
   </div>
-</div>
+</EuiControlBar>
+`;
+
+exports[`EuiControlBar props rightOffset is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={0}
+  position="fixed"
+  rightOffset={200}
+  showContent={false}
+  showOnMobile={false}
+  size="l"
+>
+  <EuiPortal>
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="euiControlBar euiControlBar--large euiControlBar--fixed"
+            style="left: 0px; right: 200px;"
+          >
+            <div
+              class="euiControlBar__controls"
+            >
+              <nav
+                aria-label="breadcrumb"
+                class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+              >
+                <button
+                  class="euiLink euiLink--subdued euiBreadcrumb"
+                  title="src"
+                  type="button"
+                >
+                  src
+                </button>
+                <div
+                  class="euiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </nav>
+              <div
+                class="euiControlBar__text"
+              >
+                Close the Hatch
+              </div>
+              <div
+                class="euiControlBar__divider"
+              />
+              <svg
+                aria-label="Sample Icon"
+                class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="euiControlBar__spacer"
+              />
+              <button
+                class="euiControlBar__tab"
+              >
+                Flight 815
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div
+        className="euiControlBar euiControlBar--large euiControlBar--fixed"
+        style={
+          Object {
+            "left": 0,
+            "maxHeight": undefined,
+            "right": 200,
+          }
+        }
+      >
+        <div
+          className="euiControlBar__controls"
+        >
+          <EuiBreadcrumbs
+            breadcrumbs={
+              Array [
+                Object {
+                  "text": "src",
+                },
+                Object {
+                  "text": "components",
+                },
+              ]
+            }
+            key="current_file_path"
+            responsive={true}
+          >
+            <nav
+              aria-label="breadcrumb"
+              className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+            >
+              <EuiInnerText>
+                <EuiLink
+                  className="euiBreadcrumb"
+                  color="subdued"
+                  title="src"
+                >
+                  <button
+                    className="euiLink euiLink--subdued euiBreadcrumb"
+                    title="src"
+                    type="button"
+                  >
+                    src
+                  </button>
+                </EuiLink>
+              </EuiInnerText>
+              <EuiBreadcrumbSeparator>
+                <div
+                  className="euiBreadcrumbSeparator"
+                />
+              </EuiBreadcrumbSeparator>
+              <EuiInnerText>
+                <span
+                  aria-current="page"
+                  className="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </EuiInnerText>
+            </nav>
+          </EuiBreadcrumbs>
+          <div
+            className="euiControlBar__text"
+            key="close_the_hatch"
+          >
+            Close the Hatch
+          </div>
+          <div
+            className="euiControlBar__divider"
+            key="divider2"
+          />
+          <EuiIcon
+            aria-label="Sample Icon"
+            className="euiControlBar__icon"
+            color="danger"
+            key="sample_icon3"
+            type="alert"
+          >
+            <EuiIconEmpty
+              aria-label="Sample Icon"
+              className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+              focusable="false"
+              style={null}
+            >
+              <svg
+                aria-label="Sample Icon"
+                className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </EuiIconEmpty>
+          </EuiIcon>
+          <div
+            className="euiControlBar__spacer"
+            key="spacer4"
+          />
+          <button
+            className="euiControlBar__tab"
+            key="flight_8155"
+            onClick={[Function]}
+          >
+            Flight 815
+          </button>
+        </div>
+      </div>
+    </Portal>
+  </EuiPortal>
+</EuiControlBar>
+`;
+
+exports[`EuiControlBar props showContent is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={0}
+  position="fixed"
+  rightOffset={0}
+  showContent={true}
+  showOnMobile={false}
+  size="l"
+>
+  <EuiPortal>
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="euiControlBar euiControlBar-isOpen euiControlBar--large euiControlBar--fixed"
+            style="left: 0px; right: 0px;"
+          >
+            <div
+              class="euiControlBar__controls"
+            >
+              <nav
+                aria-label="breadcrumb"
+                class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+              >
+                <button
+                  class="euiLink euiLink--subdued euiBreadcrumb"
+                  title="src"
+                  type="button"
+                >
+                  src
+                </button>
+                <div
+                  class="euiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </nav>
+              <div
+                class="euiControlBar__text"
+              >
+                Close the Hatch
+              </div>
+              <div
+                class="euiControlBar__divider"
+              />
+              <svg
+                aria-label="Sample Icon"
+                class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="euiControlBar__spacer"
+              />
+              <button
+                class="euiControlBar__tab"
+              >
+                Flight 815
+              </button>
+            </div>
+            <div
+              class="euiControlBar__content"
+            >
+              Content
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div
+        className="euiControlBar euiControlBar-isOpen euiControlBar--large euiControlBar--fixed"
+        style={
+          Object {
+            "left": 0,
+            "maxHeight": undefined,
+            "right": 0,
+          }
+        }
+      >
+        <div
+          className="euiControlBar__controls"
+        >
+          <EuiBreadcrumbs
+            breadcrumbs={
+              Array [
+                Object {
+                  "text": "src",
+                },
+                Object {
+                  "text": "components",
+                },
+              ]
+            }
+            key="current_file_path"
+            responsive={true}
+          >
+            <nav
+              aria-label="breadcrumb"
+              className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+            >
+              <EuiInnerText>
+                <EuiLink
+                  className="euiBreadcrumb"
+                  color="subdued"
+                  title="src"
+                >
+                  <button
+                    className="euiLink euiLink--subdued euiBreadcrumb"
+                    title="src"
+                    type="button"
+                  >
+                    src
+                  </button>
+                </EuiLink>
+              </EuiInnerText>
+              <EuiBreadcrumbSeparator>
+                <div
+                  className="euiBreadcrumbSeparator"
+                />
+              </EuiBreadcrumbSeparator>
+              <EuiInnerText>
+                <span
+                  aria-current="page"
+                  className="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </EuiInnerText>
+            </nav>
+          </EuiBreadcrumbs>
+          <div
+            className="euiControlBar__text"
+            key="close_the_hatch"
+          >
+            Close the Hatch
+          </div>
+          <div
+            className="euiControlBar__divider"
+            key="divider2"
+          />
+          <EuiIcon
+            aria-label="Sample Icon"
+            className="euiControlBar__icon"
+            color="danger"
+            key="sample_icon3"
+            type="alert"
+          >
+            <EuiIconEmpty
+              aria-label="Sample Icon"
+              className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+              focusable="false"
+              style={null}
+            >
+              <svg
+                aria-label="Sample Icon"
+                className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </EuiIconEmpty>
+          </EuiIcon>
+          <div
+            className="euiControlBar__spacer"
+            key="spacer4"
+          />
+          <button
+            className="euiControlBar__tab"
+            key="flight_8155"
+            onClick={[Function]}
+          >
+            Flight 815
+          </button>
+        </div>
+        <div
+          className="euiControlBar__content"
+        >
+          Content
+        </div>
+      </div>
+    </Portal>
+  </EuiPortal>
+</EuiControlBar>
+`;
+
+exports[`EuiControlBar props size is rendered 1`] = `
+<EuiControlBar
+  controls={
+    Array [
+      Object {
+        "breadcrumbs": Array [
+          Object {
+            "text": "src",
+          },
+          Object {
+            "text": "components",
+          },
+        ],
+        "controlType": "breadcrumbs",
+        "id": "current_file_path",
+        "responsive": true,
+      },
+      Object {
+        "controlType": "text",
+        "id": "close_the_hatch",
+        "text": "Close the Hatch",
+      },
+      Object {
+        "controlType": "divider",
+      },
+      Object {
+        "aria-label": "Sample Icon",
+        "color": "danger",
+        "controlType": "icon",
+        "iconType": "alert",
+        "id": "sample_icon",
+      },
+      Object {
+        "controlType": "spacer",
+      },
+      Object {
+        "controlType": "tab",
+        "id": "flight_815",
+        "label": "Flight 815",
+        "onClick": [Function],
+      },
+    ]
+  }
+  leftOffset={0}
+  position="fixed"
+  rightOffset={0}
+  showContent={false}
+  showOnMobile={false}
+  size="s"
+>
+  <EuiPortal>
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="euiControlBar euiControlBar--small euiControlBar--fixed"
+            style="left: 0px; right: 0px;"
+          >
+            <div
+              class="euiControlBar__controls"
+            >
+              <nav
+                aria-label="breadcrumb"
+                class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+              >
+                <button
+                  class="euiLink euiLink--subdued euiBreadcrumb"
+                  title="src"
+                  type="button"
+                >
+                  src
+                </button>
+                <div
+                  class="euiBreadcrumbSeparator"
+                />
+                <span
+                  aria-current="page"
+                  class="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </nav>
+              <div
+                class="euiControlBar__text"
+              >
+                Close the Hatch
+              </div>
+              <div
+                class="euiControlBar__divider"
+              />
+              <svg
+                aria-label="Sample Icon"
+                class="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="euiControlBar__spacer"
+              />
+              <button
+                class="euiControlBar__tab"
+              >
+                Flight 815
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div
+        className="euiControlBar euiControlBar--small euiControlBar--fixed"
+        style={
+          Object {
+            "left": 0,
+            "maxHeight": undefined,
+            "right": 0,
+          }
+        }
+      >
+        <div
+          className="euiControlBar__controls"
+        >
+          <EuiBreadcrumbs
+            breadcrumbs={
+              Array [
+                Object {
+                  "text": "src",
+                },
+                Object {
+                  "text": "components",
+                },
+              ]
+            }
+            key="current_file_path"
+            responsive={true}
+          >
+            <nav
+              aria-label="breadcrumb"
+              className="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+            >
+              <EuiInnerText>
+                <EuiLink
+                  className="euiBreadcrumb"
+                  color="subdued"
+                  title="src"
+                >
+                  <button
+                    className="euiLink euiLink--subdued euiBreadcrumb"
+                    title="src"
+                    type="button"
+                  >
+                    src
+                  </button>
+                </EuiLink>
+              </EuiInnerText>
+              <EuiBreadcrumbSeparator>
+                <div
+                  className="euiBreadcrumbSeparator"
+                />
+              </EuiBreadcrumbSeparator>
+              <EuiInnerText>
+                <span
+                  aria-current="page"
+                  className="euiBreadcrumb euiBreadcrumb--last"
+                  title="components"
+                >
+                  components
+                </span>
+              </EuiInnerText>
+            </nav>
+          </EuiBreadcrumbs>
+          <div
+            className="euiControlBar__text"
+            key="close_the_hatch"
+          >
+            Close the Hatch
+          </div>
+          <div
+            className="euiControlBar__divider"
+            key="divider2"
+          />
+          <EuiIcon
+            aria-label="Sample Icon"
+            className="euiControlBar__icon"
+            color="danger"
+            key="sample_icon3"
+            type="alert"
+          >
+            <EuiIconEmpty
+              aria-label="Sample Icon"
+              className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+              focusable="false"
+              style={null}
+            >
+              <svg
+                aria-label="Sample Icon"
+                className="euiIcon euiIcon--medium euiIcon--danger euiIcon-isLoading euiControlBar__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </EuiIconEmpty>
+          </EuiIcon>
+          <div
+            className="euiControlBar__spacer"
+            key="spacer4"
+          />
+          <button
+            className="euiControlBar__tab"
+            key="flight_8155"
+            onClick={[Function]}
+          >
+            Flight 815
+          </button>
+        </div>
+      </div>
+    </Portal>
+  </EuiPortal>
+</EuiControlBar>
 `;

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -32,6 +32,21 @@ exports[`EuiControlBar is rendered 1`] = `
         components
       </span>
     </nav>
+    <button
+      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+      data-test-subj="dts"
+      type="button"
+    >
+      <span
+        class="euiButton__content"
+      >
+        <span
+          class="euiButton__text"
+        >
+          Sound the Alarm
+        </span>
+      </span>
+    </button>
     <div
       class="euiControlBar__text"
     >
@@ -77,6 +92,13 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -144,6 +166,21 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                   components
                 </span>
               </nav>
+              <button
+                class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                data-test-subj="dts"
+                type="button"
+              >
+                <span
+                  class="euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
+                </span>
+              </button>
               <div
                 class="euiControlBar__text"
               >
@@ -236,6 +273,31 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
               </EuiInnerText>
             </nav>
           </EuiBreadcrumbs>
+          <EuiButton
+            className="euiControlBar__button"
+            color="ghost"
+            data-test-subj="dts"
+            key="sound_the_alarm1"
+            onClick={[Function]}
+            size="s"
+          >
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
+              </span>
+            </button>
+          </EuiButton>
           <div
             className="euiControlBar__text"
             key="close_the_hatch"
@@ -244,13 +306,13 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
           </div>
           <div
             className="euiControlBar__divider"
-            key="divider2"
+            key="divider3"
           />
           <EuiIcon
             aria-label="Sample Icon"
             className="euiControlBar__icon"
             color="danger"
-            key="sample_icon3"
+            key="sample_icon4"
             type="alert"
           >
             <EuiIconEmpty
@@ -273,11 +335,11 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
           </EuiIcon>
           <div
             className="euiControlBar__spacer"
-            key="spacer4"
+            key="spacer5"
           />
           <button
             className="euiControlBar__tab"
-            key="flight_8155"
+            key="flight_8156"
             onClick={[Function]}
           >
             Flight 815
@@ -305,6 +367,13 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -373,6 +442,21 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                   components
                 </span>
               </nav>
+              <button
+                class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                data-test-subj="dts"
+                type="button"
+              >
+                <span
+                  class="euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
+                </span>
+              </button>
               <div
                 class="euiControlBar__text"
               >
@@ -465,6 +549,31 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
               </EuiInnerText>
             </nav>
           </EuiBreadcrumbs>
+          <EuiButton
+            className="euiControlBar__button"
+            color="ghost"
+            data-test-subj="dts"
+            key="sound_the_alarm1"
+            onClick={[Function]}
+            size="s"
+          >
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
+              </span>
+            </button>
+          </EuiButton>
           <div
             className="euiControlBar__text"
             key="close_the_hatch"
@@ -473,13 +582,13 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
           </div>
           <div
             className="euiControlBar__divider"
-            key="divider2"
+            key="divider3"
           />
           <EuiIcon
             aria-label="Sample Icon"
             className="euiControlBar__icon"
             color="danger"
-            key="sample_icon3"
+            key="sample_icon4"
             type="alert"
           >
             <EuiIconEmpty
@@ -502,11 +611,11 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
           </EuiIcon>
           <div
             className="euiControlBar__spacer"
-            key="spacer4"
+            key="spacer5"
           />
           <button
             className="euiControlBar__tab"
-            key="flight_8155"
+            key="flight_8156"
             onClick={[Function]}
           >
             Flight 815
@@ -534,6 +643,13 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -601,6 +717,21 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                   components
                 </span>
               </nav>
+              <button
+                class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                data-test-subj="dts"
+                type="button"
+              >
+                <span
+                  class="euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
+                </span>
+              </button>
               <div
                 class="euiControlBar__text"
               >
@@ -693,6 +824,31 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
               </EuiInnerText>
             </nav>
           </EuiBreadcrumbs>
+          <EuiButton
+            className="euiControlBar__button"
+            color="ghost"
+            data-test-subj="dts"
+            key="sound_the_alarm1"
+            onClick={[Function]}
+            size="s"
+          >
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
+              </span>
+            </button>
+          </EuiButton>
           <div
             className="euiControlBar__text"
             key="close_the_hatch"
@@ -701,13 +857,13 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
           </div>
           <div
             className="euiControlBar__divider"
-            key="divider2"
+            key="divider3"
           />
           <EuiIcon
             aria-label="Sample Icon"
             className="euiControlBar__icon"
             color="danger"
-            key="sample_icon3"
+            key="sample_icon4"
             type="alert"
           >
             <EuiIconEmpty
@@ -730,11 +886,11 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
           </EuiIcon>
           <div
             className="euiControlBar__spacer"
-            key="spacer4"
+            key="spacer5"
           />
           <button
             className="euiControlBar__tab"
-            key="flight_8155"
+            key="flight_8156"
             onClick={[Function]}
           >
             Flight 815
@@ -762,6 +918,13 @@ exports[`EuiControlBar props position is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -858,6 +1021,31 @@ exports[`EuiControlBar props position is rendered 1`] = `
           </EuiInnerText>
         </nav>
       </EuiBreadcrumbs>
+      <EuiButton
+        className="euiControlBar__button"
+        color="ghost"
+        data-test-subj="dts"
+        key="sound_the_alarm1"
+        onClick={[Function]}
+        size="s"
+      >
+        <button
+          className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+          data-test-subj="dts"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            className="euiButton__content"
+          >
+            <span
+              className="euiButton__text"
+            >
+              Sound the Alarm
+            </span>
+          </span>
+        </button>
+      </EuiButton>
       <div
         className="euiControlBar__text"
         key="close_the_hatch"
@@ -866,13 +1054,13 @@ exports[`EuiControlBar props position is rendered 1`] = `
       </div>
       <div
         className="euiControlBar__divider"
-        key="divider2"
+        key="divider3"
       />
       <EuiIcon
         aria-label="Sample Icon"
         className="euiControlBar__icon"
         color="danger"
-        key="sample_icon3"
+        key="sample_icon4"
         type="alert"
       >
         <EuiIconEmpty
@@ -895,11 +1083,11 @@ exports[`EuiControlBar props position is rendered 1`] = `
       </EuiIcon>
       <div
         className="euiControlBar__spacer"
-        key="spacer4"
+        key="spacer5"
       />
       <button
         className="euiControlBar__tab"
-        key="flight_8155"
+        key="flight_8156"
         onClick={[Function]}
       >
         Flight 815
@@ -925,6 +1113,13 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -992,6 +1187,21 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                   components
                 </span>
               </nav>
+              <button
+                class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                data-test-subj="dts"
+                type="button"
+              >
+                <span
+                  class="euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
+                </span>
+              </button>
               <div
                 class="euiControlBar__text"
               >
@@ -1084,6 +1294,31 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
               </EuiInnerText>
             </nav>
           </EuiBreadcrumbs>
+          <EuiButton
+            className="euiControlBar__button"
+            color="ghost"
+            data-test-subj="dts"
+            key="sound_the_alarm1"
+            onClick={[Function]}
+            size="s"
+          >
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
+              </span>
+            </button>
+          </EuiButton>
           <div
             className="euiControlBar__text"
             key="close_the_hatch"
@@ -1092,13 +1327,13 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
           </div>
           <div
             className="euiControlBar__divider"
-            key="divider2"
+            key="divider3"
           />
           <EuiIcon
             aria-label="Sample Icon"
             className="euiControlBar__icon"
             color="danger"
-            key="sample_icon3"
+            key="sample_icon4"
             type="alert"
           >
             <EuiIconEmpty
@@ -1121,11 +1356,11 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
           </EuiIcon>
           <div
             className="euiControlBar__spacer"
-            key="spacer4"
+            key="spacer5"
           />
           <button
             className="euiControlBar__tab"
-            key="flight_8155"
+            key="flight_8156"
             onClick={[Function]}
           >
             Flight 815
@@ -1153,6 +1388,13 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -1220,6 +1462,21 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                   components
                 </span>
               </nav>
+              <button
+                class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                data-test-subj="dts"
+                type="button"
+              >
+                <span
+                  class="euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
+                </span>
+              </button>
               <div
                 class="euiControlBar__text"
               >
@@ -1317,6 +1574,31 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
               </EuiInnerText>
             </nav>
           </EuiBreadcrumbs>
+          <EuiButton
+            className="euiControlBar__button"
+            color="ghost"
+            data-test-subj="dts"
+            key="sound_the_alarm1"
+            onClick={[Function]}
+            size="s"
+          >
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
+              </span>
+            </button>
+          </EuiButton>
           <div
             className="euiControlBar__text"
             key="close_the_hatch"
@@ -1325,13 +1607,13 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
           </div>
           <div
             className="euiControlBar__divider"
-            key="divider2"
+            key="divider3"
           />
           <EuiIcon
             aria-label="Sample Icon"
             className="euiControlBar__icon"
             color="danger"
-            key="sample_icon3"
+            key="sample_icon4"
             type="alert"
           >
             <EuiIconEmpty
@@ -1354,11 +1636,11 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
           </EuiIcon>
           <div
             className="euiControlBar__spacer"
-            key="spacer4"
+            key="spacer5"
           />
           <button
             className="euiControlBar__tab"
-            key="flight_8155"
+            key="flight_8156"
             onClick={[Function]}
           >
             Flight 815
@@ -1391,6 +1673,13 @@ exports[`EuiControlBar props size is rendered 1`] = `
         "controlType": "breadcrumbs",
         "id": "current_file_path",
         "responsive": true,
+      },
+      Object {
+        "controlType": "button",
+        "data-test-subj": "dts",
+        "id": "sound_the_alarm",
+        "label": "Sound the Alarm",
+        "onClick": [Function],
       },
       Object {
         "controlType": "text",
@@ -1458,6 +1747,21 @@ exports[`EuiControlBar props size is rendered 1`] = `
                   components
                 </span>
               </nav>
+              <button
+                class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                data-test-subj="dts"
+                type="button"
+              >
+                <span
+                  class="euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
+                </span>
+              </button>
               <div
                 class="euiControlBar__text"
               >
@@ -1550,6 +1854,31 @@ exports[`EuiControlBar props size is rendered 1`] = `
               </EuiInnerText>
             </nav>
           </EuiBreadcrumbs>
+          <EuiButton
+            className="euiControlBar__button"
+            color="ghost"
+            data-test-subj="dts"
+            key="sound_the_alarm1"
+            onClick={[Function]}
+            size="s"
+          >
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
+              </span>
+            </button>
+          </EuiButton>
           <div
             className="euiControlBar__text"
             key="close_the_hatch"
@@ -1558,13 +1887,13 @@ exports[`EuiControlBar props size is rendered 1`] = `
           </div>
           <div
             className="euiControlBar__divider"
-            key="divider2"
+            key="divider3"
           />
           <EuiIcon
             aria-label="Sample Icon"
             className="euiControlBar__icon"
             color="danger"
-            key="sample_icon3"
+            key="sample_icon4"
             type="alert"
           >
             <EuiIconEmpty
@@ -1587,11 +1916,11 @@ exports[`EuiControlBar props size is rendered 1`] = `
           </EuiIcon>
           <div
             className="euiControlBar__spacer"
-            key="spacer4"
+            key="spacer5"
           />
           <button
             className="euiControlBar__tab"
-            key="flight_8155"
+            key="flight_8156"
             onClick={[Function]}
           >
             Flight 815

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -3,56 +3,89 @@
 exports[`EuiControlBar is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiControlBar testClass1 testClass2 euiControlBar--large"
+  class="euiControlBar testClass1 testClass2 euiControlBar--large euiControlBar--fixed"
   data-test-subj="test subject string"
+  style="left: 0px; right: 0px;"
 >
   <div
     class="euiControlBar__controls"
   >
-    <button
-      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
-      type="button"
+    <nav
+      aria-label="breadcrumb"
+      class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
     >
-      <span
-        class="euiButton__content"
+      <button
+        class="euiLink euiLink--subdued euiBreadcrumb"
+        title="src"
+        type="button"
       >
-        <span
-          class="euiButton__text"
-        >
-          Sound the Alarm
-        </span>
-      </span>
-    </button>
-    <button
-      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
-      type="button"
-    >
-      <span
-        class="euiButton__content"
-      >
-        <span
-          class="euiButton__text"
-        >
-          Close the Hatch
-        </span>
-      </span>
-    </button>
-    <button
-      aria-label="Sample Icon"
-      class="euiButtonIcon euiButtonIcon--ghost euiControlBar__buttonIcon"
-      data-test-subj="Sample Icon"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+        src
+      </button>
+      <div
+        class="euiBreadcrumbSeparator"
       />
-    </button>
+      <span
+        aria-current="page"
+        class="euiBreadcrumb euiBreadcrumb--last"
+        title="components"
+      >
+        components
+      </span>
+    </nav>
+    <div
+      class="euiControlBar__text"
+      data-test-subj="dts"
+    >
+      Close the Hatch
+    </div>
+    <div
+      class="euiControlBar__spacer"
+    />
+  </div>
+</div>
+`;
+
+exports[`mobile control bar is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiControlBar testClass1 testClass2 euiControlBar--large euiControlBar--fixed euiControlBar--showOnMobile"
+  data-test-subj="test subject string"
+  style="left: 0px; right: 0px;"
+>
+  <div
+    class="euiControlBar__controls"
+  >
+    <nav
+      aria-label="breadcrumb"
+      class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+    >
+      <button
+        class="euiLink euiLink--subdued euiBreadcrumb"
+        title="src"
+        type="button"
+      >
+        src
+      </button>
+      <div
+        class="euiBreadcrumbSeparator"
+      />
+      <span
+        aria-current="page"
+        class="euiBreadcrumb euiBreadcrumb--last"
+        title="components"
+      >
+        components
+      </span>
+    </nav>
+    <div
+      class="euiControlBar__text"
+      data-test-subj="dts"
+    >
+      Close the Hatch
+    </div>
+    <div
+      class="euiControlBar__spacer"
+    />
   </div>
 </div>
 `;

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -10,9 +10,7 @@ exports[`EuiControlBar is rendered 1`] = `
     class="euiControlBar__controls"
   >
     <button
-      aria-label="Control Bar - Sound the Alarm"
-      class="euiButton euiButton--ghost euiControlBar__button"
-      data-test-subj="Sound the Alarm"
+      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
       type="button"
     >
       <span
@@ -21,18 +19,12 @@ exports[`EuiControlBar is rendered 1`] = `
         <span
           class="euiButton__text"
         >
-          <div
-            class="euiText euiText--small"
-          >
-            Sound the Alarm
-          </div>
+          Sound the Alarm
         </span>
       </span>
     </button>
     <button
-      aria-label="Control Bar - Close the Hatch"
-      class="euiButton euiButton--ghost euiControlBar__button"
-      data-test-subj="Close the Hatch"
+      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
       type="button"
     >
       <span
@@ -41,11 +33,7 @@ exports[`EuiControlBar is rendered 1`] = `
         <span
           class="euiButton__text"
         >
-          <div
-            class="euiText euiText--small"
-          >
-            Close the Hatch
-          </div>
+          Close the Hatch
         </span>
       </span>
     </button>

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -9,30 +9,10 @@ exports[`EuiControlBar is rendered 1`] = `
   <div
     class="euiControlBar__controls"
   >
-    <nav
-      aria-label="breadcrumb"
-      class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
-    >
-      <button
-        class="euiLink euiLink--subdued euiBreadcrumb"
-        title="src"
-        type="button"
-      >
-        src
-      </button>
-      <div
-        class="euiBreadcrumbSeparator"
-      />
-      <span
-        aria-current="page"
-        class="euiBreadcrumb euiBreadcrumb--last"
-        title="components"
-      >
-        components
-      </span>
-    </nav>
     <button
-      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+      aria-label="Control Bar - Sound the Alarm"
+      class="euiButton euiButton--ghost euiControlBar__button"
+      data-test-subj="Sound the Alarm"
       type="button"
     >
       <span
@@ -41,12 +21,18 @@ exports[`EuiControlBar is rendered 1`] = `
         <span
           class="euiButton__text"
         >
-          Sound the Alarm
+          <div
+            class="euiText euiText--small"
+          >
+            Sound the Alarm
+          </div>
         </span>
       </span>
     </button>
     <button
-      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+      aria-label="Control Bar - Close the Hatch"
+      class="euiButton euiButton--ghost euiControlBar__button"
+      data-test-subj="Close the Hatch"
       type="button"
     >
       <span
@@ -55,7 +41,11 @@ exports[`EuiControlBar is rendered 1`] = `
         <span
           class="euiButton__text"
         >
-          Close the Hatch
+          <div
+            class="euiText euiText--small"
+          >
+            Close the Hatch
+          </div>
         </span>
       </span>
     </button>
@@ -63,123 +53,6 @@ exports[`EuiControlBar is rendered 1`] = `
       aria-label="Sample Icon"
       class="euiButtonIcon euiButtonIcon--ghost euiControlBar__buttonIcon"
       data-test-subj="Sample Icon"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
-    </button>
-    <div
-      class="euiControlBar__spacer"
-    />
-    <button
-      aria-label="Repo Status"
-      class="euiButtonIcon euiButtonIcon--warning euiControlBar__buttonIcon"
-      data-test-subj="Repo Status"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
-    </button>
-  </div>
-</div>
-`;
-
-exports[`mobile control bar is rendered 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiControlBar testClass1 testClass2 euiControlBar--large euiControlBar--showOnMobile"
-  data-test-subj="test subject string"
->
-  <div
-    class="euiControlBar__controls"
-  >
-    <nav
-      aria-label="breadcrumb"
-      class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
-    >
-      <button
-        class="euiLink euiLink--subdued euiBreadcrumb"
-        title="src"
-        type="button"
-      >
-        src
-      </button>
-      <div
-        class="euiBreadcrumbSeparator"
-      />
-      <span
-        aria-current="page"
-        class="euiBreadcrumb euiBreadcrumb--last"
-        title="components"
-      >
-        components
-      </span>
-    </nav>
-    <button
-      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
-      type="button"
-    >
-      <span
-        class="euiButton__content"
-      >
-        <span
-          class="euiButton__text"
-        >
-          Sound the Alarm
-        </span>
-      </span>
-    </button>
-    <button
-      class="euiButton euiButton--ghost euiButton--small euiControlBar__button"
-      type="button"
-    >
-      <span
-        class="euiButton__content"
-      >
-        <span
-          class="euiButton__text"
-        >
-          Close the Hatch
-        </span>
-      </span>
-    </button>
-    <button
-      aria-label="Sample Icon"
-      class="euiButtonIcon euiButtonIcon--ghost euiControlBar__buttonIcon"
-      data-test-subj="Sample Icon"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
-    </button>
-    <div
-      class="euiControlBar__spacer"
-    />
-    <button
-      aria-label="Repo Status"
-      class="euiButtonIcon euiButtonIcon--warning euiControlBar__buttonIcon"
-      data-test-subj="Repo Status"
       type="button"
     >
       <svg

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -172,15 +172,15 @@
 }
 
 .euiControlBar__tab {
+  @include euiTextTruncate;
+  @include euiFontSizeS;
+  color: $euiControlBarText;
   padding: 0 $euiSize;
   text-align: center;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  word-wrap: none;
 
-  &:hover {
+  &:hover,
+  &:focus {
     text-decoration: underline;
     cursor: pointer;
   }
@@ -192,16 +192,8 @@
   }
 }
 
-.euiControlBar__euiButton + .euiControlBar__tab--active {
-  box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade), -1px 0 0 $euiControlBarBackground;
-}
-
 @each $colorName, $colorValue in $euiButtonTypes {
   .euiControlBar__controls {
-    .euiText--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
-    }
-
     .euiLink.euiLink--#{$colorName} {
       color: makeHighContrastColor($colorValue, $euiControlBarBackground);
 

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -1,18 +1,17 @@
 .euiControlBar {
-  background: lighten($euiColorInk, 5%);
+  background: $euiControlBarBackground;
   width: 100%;
-  color: $controlBarText;
+  color: $euiControlBarText;
   display: flex;
   flex-direction: column;
   position: fixed;
   // This large box shadow helps prevent a flicker of dark
   // background when the content is shown and hidden
-  box-shadow: inset 0 $controlBarInitialHeight 0 $controlBarBackground, inset 0 600rem 0 $euiColorLightestShade;
-  z-index: 20000;
+  box-shadow: inset 0 $euiControlBarInitialHeight 0 $euiControlBarBackground, inset 0 600rem 0 $euiPageBackgroundColor;
+  z-index: $euiZMask;
   left: 0;
   bottom: 0;
   transform: translateY(0);
-  box-sizing: border-box;
 
   &.euiControlBar--navCollapsed {
     left: $euiNavDrawerWidthCollapsed;
@@ -48,44 +47,42 @@
     bottom: -25vh;
   }
 
-  &.euiControlBar--large {
-    height: $controlBarInitialHeight;
-  }
-
-  &.euiControlBar--medium {
-    height: $controlBarInitialHeight;
-  }
-
+  &.euiControlBar--large,
+  &.euiControlBar--medium,
   &.euiControlBar--small {
-    height: $controlBarInitialHeight;
+    height: $euiControlBarInitialHeight;
   }
 }
 
 .euiControlBar__controls {
-  height: $controlBarInitialHeight;
+  height: $euiControlBarInitialHeight;
   width: 100%;
   display: flex;
   align-items: center;
+  overflow-x: auto;
+
+  .euiBreadcrumbSeparator {
+    background: $euiControlBarBorderColor;
+  }
 }
 
 .euiControlBar__content {
   @include euiScrollBar;
+  overflow-y: auto;
   width: 100%;
-  height: calc(100% - #{$controlBarInitialHeight});
-  background-color: $euiColorLightestShade;
-  box-sizing: border-box;
+  height: calc(100% - #{$euiControlBarInitialHeight});
+  background-color: $euiPageBackgroundColor;
   animation-name: showContent;
   animation-duration: $euiAnimSpeedSlow;
   animation-iteration-count: 1;
   animation-timing-function: $euiAnimSlightResistance;
   color: $euiColorDarkestShade;
-  overflow-y: scroll;
 }
 
 @keyframes openPanelLarge {
   0% {
     // Accounts for the initial height offset from the top
-    transform: translateY(calc((#{$controlBarInitialHeight} * 3) * -1));
+    transform: translateY(calc((#{$euiControlBarInitialHeight} * 3) * -1));
   }
 
   100% {
@@ -95,7 +92,7 @@
 
 @keyframes openPanelMedium {
   0% {
-    transform: translateY(-$controlBarInitialHeight);
+    transform: translateY(-$euiControlBarInitialHeight);
   }
 
   100% {
@@ -105,7 +102,7 @@
 
 @keyframes openPanelSmall {
   0% {
-    transform: translateY(-$controlBarInitialHeight);
+    transform: translateY(-$euiControlBarInitialHeight);
   }
 
   100% {
@@ -124,16 +121,18 @@
 }
 
 .euiControlBar__buttonIcon {
-  min-width: $controlBarInitialHeight;
+  min-width: $euiControlBarInitialHeight;
+  min-height: $euiControlBarInitialHeight;
 }
 
 .euiControlBar__button {
-  border-radius: .125rem;
-  height: $euiSizeXL;
+  border-radius: $euiBorderRadius / 2;
   margin-left: $euiSizeXS;
+  flex-shrink: 0;
+  font-size: $euiFontSizeS;
 
   &:enabled:hover {
-    transform: translateY(0);
+    transform: none;
     box-shadow: none;
   }
 
@@ -144,7 +143,6 @@
 }
 
 .euiControlBar__spacer {
-  display: flex;
   flex-grow: 1;
   height: 100%;
 }
@@ -152,23 +150,22 @@
 .euiControlBar__divider {
   height: 100%;
   width: 1px;
-  background-color: $controlBarBorderColor;
+  background-color: $euiControlBarBorderColor;
 }
 
 .euiControlBar__euiText {
   padding: 0 $euiSizeS;
-  color: $controlBarText;
+  color: $euiControlBarText;
 }
 
 .euiControlBar__tab {
   padding: 0 $euiSize;
   text-align: center;
-  box-sizing: border-box;
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: $controlBarText;
+  word-wrap: none;
 
   &:hover {
     text-decoration: underline;
@@ -176,24 +173,24 @@
   }
 
   &.euiControlBar__tab--active {
-    background-color: $euiColorLightestShade;
+    background-color: $euiPageBackgroundColor;
     box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade);
     color: makeHighContrastColor($euiColorPrimary, $euiColorLightestShade);
   }
 }
 
 .euiControlBar__euiButton + .euiControlBar__tab--active {
-  box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade), -1px 0 0 $controlBarBackground;
+  box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade), -1px 0 0 $euiControlBarBackground;
 }
 
-@each $colorName, $colorValue in $buttonTypes {
+@each $colorName, $colorValue in $euiButtonTypes {
   .euiControlBar__controls {
     .euiText--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $controlBarBackground);
+      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
     }
 
     .euiLink.euiLink--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $controlBarBackground);
+      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
 
       &:hover {
         color: tintOrShade($colorValue, 30%, 30%);
@@ -201,13 +198,19 @@
     }
 
     .euiControlBar__button.euiButton--#{$colorName}:enabled {
-      color: makeHighContrastColor($colorValue, $controlBarBackground);
-      border-color: makeHighContrastColor($colorValue, $controlBarBackground);
+      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
+      border-color: makeHighContrastColor($colorValue, $euiControlBarBackground);
       box-shadow: none;
     }
 
     .euiControlBar__buttonIcon .euiIcon--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $controlBarBackground);
+      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
     }
+  }
+}
+
+@include euiBreakpoint('xs', 's') {
+  .euiControlBar:not(.euiControlBar--showOnMobile) {
+    display: none;
   }
 }

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -124,19 +124,21 @@
 // CONTROL TYPES
 
 .euiControlBar__icon {
+  flex-shrink: 0;
   margin-left: $euiSizeS;
   margin-right: $euiSizeS;
 }
 
 .euiControlBar__buttonIcon {
+  flex-shrink: 0;
   min-width: $euiControlBarInitialHeight;
   min-height: $euiControlBarInitialHeight;
 }
 
 .euiControlBar__button {
+  flex-shrink: 0;
   border-radius: $euiBorderRadius / 2;
   margin-left: $euiSizeXS;
-  flex-shrink: 0;
   font-size: $euiFontSizeS;
 
   &:enabled:hover {
@@ -156,12 +158,13 @@
 }
 
 .euiControlBar__divider {
+  flex-shrink: 0;
   height: 100%;
   width: 1px;
   background-color: $euiControlBarBorderColor;
 }
 
-.euiControlBar__euiText {
+.euiControlBar__text {
   @include euiTextTruncate;
   @include euiFontSizeS;
   padding: 0 $euiSizeS;

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -9,6 +9,7 @@
   bottom: 0;
   transform: translateY(0);
   height: $euiControlBarInitialHeight;
+  max-height: $euiControlBarMaxHeight;
 
   &--fixed {
     position: fixed;
@@ -32,20 +33,20 @@
 
   &-isOpen.euiControlBar--large {
     animation-name: euiControlBarOpenPanelLarge;
-    height: calc(100vh - 5rem);
-    bottom: -100vh;
+    height: $euiControlBarMaxHeight;
+    bottom: map-get($euiControlBarHeights, 'l') * -1;
   }
 
   &-isOpen.euiControlBar--medium {
     animation-name: euiControlBarOpenPanelMedium;
-    height: 50vh;
-    bottom: -50vh;
+    height: map-get($euiControlBarHeights, 'm');
+    bottom: map-get($euiControlBarHeights, 'm') * -1;
   }
 
   &-isOpen.euiControlBar--small {
-    animation-name: euiControlBarOpenPanelMedium;
-    height: 25vh;
-    bottom: -25vh;
+    animation-name: euiControlBarOpenPanelSmall;
+    height: map-get($euiControlBarHeights, 's');
+    bottom: map-get($euiControlBarHeights, 's') * -1;
   }
 }
 
@@ -190,7 +191,7 @@
   }
 
   100% {
-    transform: translateY(-100vh);
+    transform: translateY(map-get($euiControlBarHeights, 'l') * -1);
   }
 }
 
@@ -200,7 +201,7 @@
   }
 
   100% {
-    transform: translateY(-50.09vh);
+    transform: translateY(map-get($euiControlBarHeights, 'm') * -1);
   }
 }
 
@@ -210,7 +211,7 @@
   }
 
   100% {
-    transform: translateY(-25.09vh);
+    transform: translateY(map-get($euiControlBarHeights, 's') * -1);
   }
 }
 

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -1,6 +1,5 @@
 .euiControlBar {
   background: $euiControlBarBackground;
-  width: 100%;
   color: $euiControlBarText;
   display: flex;
   flex-direction: column;
@@ -9,40 +8,29 @@
   // background when the content is shown and hidden
   box-shadow: inset 0 $euiControlBarInitialHeight 0 $euiControlBarBackground, inset 0 600rem 0 $euiPageBackgroundColor;
   z-index: $euiZMask;
-  left: 0;
   bottom: 0;
   transform: translateY(0);
 
-  &.euiControlBar--navCollapsed {
-    left: $euiNavDrawerWidthCollapsed;
-    width: calc(100% - #{$euiNavDrawerWidthCollapsed});
-  }
-
-  &.euiControlBar--navExpanded {
-    left: $euiNavDrawerWidthExpanded;
-    width: calc(100% - #{$euiNavDrawerWidthExpanded});
-  }
-
-  &.euiControlBar--open {
+  &.euiControlBar-isOpen {
     animation-duration: $euiAnimSpeedNormal;
     animation-timing-function: $euiAnimSlightResistance;
     animation-fill-mode: forwards;
   }
 
-  &.euiControlBar--open.euiControlBar--large {
-    animation-name: openPanelLarge;
+  &.euiControlBar-isOpen.euiControlBar--large {
+    animation-name: euiControlBarOpenPanelLarge;
     height: calc(100vh - 5rem);
     bottom: -100vh;
   }
 
-  &.euiControlBar--open.euiControlBar--medium {
-    animation-name: openPanelMedium;
+  &.euiControlBar-isOpen.euiControlBar--medium {
+    animation-name: euiControlBarOpenPanelMedium;
     height: 50vh;
     bottom: -50vh;
   }
 
-  &.euiControlBar--open.euiControlBar--small {
-    animation-name: openPanelMedium;
+  &.euiControlBar-isOpen.euiControlBar--small {
+    animation-name: euiControlBarOpenPanelMedium;
     height: 25vh;
     bottom: -25vh;
   }
@@ -61,9 +49,14 @@
   align-items: center;
   overflow-y: hidden; // Ensures the movement of buttons in :focus don't cause scrollbars
   overflow-x: auto;
+  padding: 0 $euiSizeM;
 
   .euiBreadcrumbSeparator {
     background: $euiControlBarBorderColor;
+  }
+
+  .euiBreadcrumb.euiLink--subdued {
+    color: makeHighContrastColor($euiColorDarkShade, $euiControlBarBackground);
   }
 }
 
@@ -73,52 +66,11 @@
   width: 100%;
   height: calc(100% - #{$euiControlBarInitialHeight});
   background-color: $euiPageBackgroundColor;
-  animation-name: showContent;
+  animation-name: euiControlBarShowContent;
   animation-duration: $euiAnimSpeedSlow;
   animation-iteration-count: 1;
   animation-timing-function: $euiAnimSlightResistance;
   color: $euiColorDarkestShade;
-}
-
-@keyframes openPanelLarge {
-  0% {
-    // Accounts for the initial height offset from the top
-    transform: translateY(calc((#{$euiControlBarInitialHeight} * 3) * -1));
-  }
-
-  100% {
-    transform: translateY(-100vh);
-  }
-}
-
-@keyframes openPanelMedium {
-  0% {
-    transform: translateY(-$euiControlBarInitialHeight);
-  }
-
-  100% {
-    transform: translateY(-50vh);
-  }
-}
-
-@keyframes openPanelSmall {
-  0% {
-    transform: translateY(-$euiControlBarInitialHeight);
-  }
-
-  100% {
-    transform: translateY(-25vh);
-  }
-}
-
-@keyframes showContent {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
 }
 
 // CONTROL TYPES
@@ -169,6 +121,10 @@
   @include euiFontSizeS;
   padding: 0 $euiSizeS;
   color: $euiControlBarText;
+
+  &:last-child {
+    padding-right: 0;
+  }
 }
 
 .euiControlBar__tab {
@@ -208,7 +164,7 @@
       box-shadow: none;
     }
 
-    .euiControlBar__buttonIcon .euiIcon--#{$colorName} {
+    .euiButtonIcon--#{$colorName} {
       color: makeHighContrastColor($colorValue, $euiControlBarBackground);
     }
   }
@@ -217,5 +173,46 @@
 @include euiBreakpoint('xs', 's') {
   .euiControlBar:not(.euiControlBar--showOnMobile) {
     display: none;
+  }
+}
+
+@keyframes euiControlBarOpenPanelLarge {
+  0% {
+    // Accounts for the initial height offset from the top
+    transform: translateY(calc((#{$euiControlBarInitialHeight} * 3) * -1));
+  }
+
+  100% {
+    transform: translateY(-100vh);
+  }
+}
+
+@keyframes euiControlBarOpenPanelMedium {
+  0% {
+    transform: translateY(-$euiControlBarInitialHeight);
+  }
+
+  100% {
+    transform: translateY(-50.09vh);
+  }
+}
+
+@keyframes euiControlBarOpenPanelSmall {
+  0% {
+    transform: translateY(-$euiControlBarInitialHeight);
+  }
+
+  100% {
+    transform: translateY(-25.09vh);
+  }
+}
+
+@keyframes euiControlBarShowContent {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
   }
 }

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -3,42 +3,49 @@
   color: $euiControlBarText;
   display: flex;
   flex-direction: column;
-  position: fixed;
   // This large box shadow helps prevent a flicker of dark
   // background when the content is shown and hidden
   box-shadow: inset 0 $euiControlBarInitialHeight 0 $euiControlBarBackground, inset 0 600rem 0 $euiPageBackgroundColor;
-  z-index: $euiZMask;
   bottom: 0;
   transform: translateY(0);
+  height: $euiControlBarInitialHeight;
 
-  &.euiControlBar-isOpen {
+  &--fixed {
+    position: fixed;
+    z-index: $euiZMask;
+  }
+
+  &--absolute {
+    position: absolute;
+    z-index: $euiZLevel1;
+  }
+
+  &--relative {
+    position: relative;
+  }
+
+  &-isOpen {
     animation-duration: $euiAnimSpeedNormal;
     animation-timing-function: $euiAnimSlightResistance;
     animation-fill-mode: forwards;
   }
 
-  &.euiControlBar-isOpen.euiControlBar--large {
+  &-isOpen.euiControlBar--large {
     animation-name: euiControlBarOpenPanelLarge;
     height: calc(100vh - 5rem);
     bottom: -100vh;
   }
 
-  &.euiControlBar-isOpen.euiControlBar--medium {
+  &-isOpen.euiControlBar--medium {
     animation-name: euiControlBarOpenPanelMedium;
     height: 50vh;
     bottom: -50vh;
   }
 
-  &.euiControlBar-isOpen.euiControlBar--small {
+  &-isOpen.euiControlBar--small {
     animation-name: euiControlBarOpenPanelMedium;
     height: 25vh;
     bottom: -25vh;
-  }
-
-  &.euiControlBar--large,
-  &.euiControlBar--medium,
-  &.euiControlBar--small {
-    height: $euiControlBarInitialHeight;
   }
 }
 

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -59,6 +59,7 @@
   width: 100%;
   display: flex;
   align-items: center;
+  overflow-y: hidden; // Ensures the movement of buttons in :focus don't cause scrollbars
   overflow-x: auto;
 
   .euiBreadcrumbSeparator {
@@ -121,6 +122,11 @@
 }
 
 // CONTROL TYPES
+
+.euiControlBar__icon {
+  margin-left: $euiSizeS;
+  margin-right: $euiSizeS;
+}
 
 .euiControlBar__buttonIcon {
   min-width: $euiControlBarInitialHeight;

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -1,17 +1,18 @@
 .euiControlBar {
-  background: $euiControlBarBackground;
+  background: lighten($euiColorInk, 5%);
   width: 100%;
-  color: $euiControlBarText;
+  color: $controlBarText;
   display: flex;
   flex-direction: column;
   position: fixed;
   // This large box shadow helps prevent a flicker of dark
   // background when the content is shown and hidden
-  box-shadow: inset 0 $euiControlBarInitialHeight 0 $euiControlBarBackground, inset 0 600rem 0 $euiPageBackgroundColor;
-  z-index: $euiZMask;
+  box-shadow: inset 0 $controlBarInitialHeight 0 $controlBarBackground, inset 0 600rem 0 $euiColorLightestShade;
+  z-index: 20000;
   left: 0;
   bottom: 0;
   transform: translateY(0);
+  box-sizing: border-box;
 
   &.euiControlBar--navCollapsed {
     left: $euiNavDrawerWidthCollapsed;
@@ -47,43 +48,44 @@
     bottom: -25vh;
   }
 
-  &.euiControlBar--large,
-  &.euiControlBar--medium,
+  &.euiControlBar--large {
+    height: $controlBarInitialHeight;
+  }
+
+  &.euiControlBar--medium {
+    height: $controlBarInitialHeight;
+  }
+
   &.euiControlBar--small {
-    height: $euiControlBarInitialHeight;
+    height: $controlBarInitialHeight;
   }
 }
 
 .euiControlBar__controls {
-  height: $euiControlBarInitialHeight;
+  height: $controlBarInitialHeight;
   width: 100%;
   display: flex;
   align-items: center;
-  overflow-x: auto;
-  padding: 0 $euiSizeM;
-
-  .euiBreadcrumbSeparator {
-    background: $euiControlBarBorderColor;
-  }
 }
 
 .euiControlBar__content {
   @include euiScrollBar;
-  overflow-y: auto;
   width: 100%;
-  height: calc(100% - #{$euiControlBarInitialHeight});
-  background-color: $euiPageBackgroundColor;
+  height: calc(100% - #{$controlBarInitialHeight});
+  background-color: $euiColorLightestShade;
+  box-sizing: border-box;
   animation-name: showContent;
   animation-duration: $euiAnimSpeedSlow;
   animation-iteration-count: 1;
   animation-timing-function: $euiAnimSlightResistance;
   color: $euiColorDarkestShade;
+  overflow-y: scroll;
 }
 
 @keyframes openPanelLarge {
   0% {
     // Accounts for the initial height offset from the top
-    transform: translateY(calc((#{$euiControlBarInitialHeight} * 3) * -1));
+    transform: translateY(calc((#{$controlBarInitialHeight} * 3) * -1));
   }
 
   100% {
@@ -93,21 +95,21 @@
 
 @keyframes openPanelMedium {
   0% {
-    transform: translateY(-$euiControlBarInitialHeight);
+    transform: translateY(-$controlBarInitialHeight);
   }
 
   100% {
-    transform: translateY(-50.09vh);
+    transform: translateY(-50vh);
   }
 }
 
 @keyframes openPanelSmall {
   0% {
-    transform: translateY(-$euiControlBarInitialHeight);
+    transform: translateY(-$controlBarInitialHeight);
   }
 
   100% {
-    transform: translateY(-25.09vh);
+    transform: translateY(-25vh);
   }
 }
 
@@ -122,18 +124,16 @@
 }
 
 .euiControlBar__buttonIcon {
-  min-width: $euiControlBarInitialHeight;
-  min-height: $euiControlBarInitialHeight;
+  min-width: $controlBarInitialHeight;
 }
 
 .euiControlBar__button {
-  border-radius: $euiBorderRadius / 2;
+  border-radius: .125rem;
+  height: $euiSizeXL;
   margin-left: $euiSizeXS;
-  flex-shrink: 0;
-  font-size: $euiFontSizeS;
 
   &:enabled:hover {
-    transform: none;
+    transform: translateY(0);
     box-shadow: none;
   }
 
@@ -144,6 +144,7 @@
 }
 
 .euiControlBar__spacer {
+  display: flex;
   flex-grow: 1;
   height: 100%;
 }
@@ -151,26 +152,23 @@
 .euiControlBar__divider {
   height: 100%;
   width: 1px;
-  background-color: $euiControlBarBorderColor;
+  background-color: $controlBarBorderColor;
 }
 
 .euiControlBar__euiText {
   padding: 0 $euiSizeS;
-  color: $euiControlBarText;
-
-  &:last-child {
-    padding-right: 0;
-  }
+  color: $controlBarText;
 }
 
 .euiControlBar__tab {
   padding: 0 $euiSize;
   text-align: center;
+  box-sizing: border-box;
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  word-wrap: none;
+  color: $controlBarText;
 
   &:hover {
     text-decoration: underline;
@@ -178,24 +176,24 @@
   }
 
   &.euiControlBar__tab--active {
-    background-color: $euiPageBackgroundColor;
+    background-color: $euiColorLightestShade;
     box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade);
     color: makeHighContrastColor($euiColorPrimary, $euiColorLightestShade);
   }
 }
 
 .euiControlBar__euiButton + .euiControlBar__tab--active {
-  box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade), -1px 0 0 $euiControlBarBackground;
+  box-shadow: inset 0 4px 0 makeHighContrastColor($euiColorPrimary, $euiColorLightestShade), -1px 0 0 $controlBarBackground;
 }
 
-@each $colorName, $colorValue in $euiButtonTypes {
+@each $colorName, $colorValue in $buttonTypes {
   .euiControlBar__controls {
     .euiText--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
+      color: makeHighContrastColor($colorValue, $controlBarBackground);
     }
 
     .euiLink.euiLink--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
+      color: makeHighContrastColor($colorValue, $controlBarBackground);
 
       &:hover {
         color: tintOrShade($colorValue, 30%, 30%);
@@ -203,19 +201,13 @@
     }
 
     .euiControlBar__button.euiButton--#{$colorName}:enabled {
-      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
-      border-color: makeHighContrastColor($colorValue, $euiControlBarBackground);
+      color: makeHighContrastColor($colorValue, $controlBarBackground);
+      border-color: makeHighContrastColor($colorValue, $controlBarBackground);
       box-shadow: none;
     }
 
     .euiControlBar__buttonIcon .euiIcon--#{$colorName} {
-      color: makeHighContrastColor($colorValue, $euiControlBarBackground);
+      color: makeHighContrastColor($colorValue, $controlBarBackground);
     }
-  }
-}
-
-@include euiBreakpoint('xs', 's') {
-  .euiControlBar:not(.euiControlBar--showOnMobile) {
-    display: none;
   }
 }

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -120,6 +120,8 @@
   }
 }
 
+// CONTROL TYPES
+
 .euiControlBar__buttonIcon {
   min-width: $euiControlBarInitialHeight;
   min-height: $euiControlBarInitialHeight;
@@ -154,6 +156,8 @@
 }
 
 .euiControlBar__euiText {
+  @include euiTextTruncate;
+  @include euiFontSizeS;
   padding: 0 $euiSizeS;
   color: $euiControlBarText;
 }

--- a/src/components/control_bar/_variables.scss
+++ b/src/components/control_bar/_variables.scss
@@ -1,4 +1,4 @@
-$controlBarBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorInk);
-$controlBarText: lighten(makeHighContrastColor($euiColorLightestShade, $controlBarBackground), 20%);
-$controlBarBorderColor: rgba(255, 255, 255, .2);
-$controlBarInitialHeight: $euiSizeXXL;
+$euiControlBarBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorInk);
+$euiControlBarText: lighten(makeHighContrastColor($euiColorLightestShade, $euiControlBarBackground), 20%);
+$euiControlBarBorderColor: transparentize($euiColorGhost, .8);
+$euiControlBarInitialHeight: $euiSizeXXL;

--- a/src/components/control_bar/_variables.scss
+++ b/src/components/control_bar/_variables.scss
@@ -2,3 +2,12 @@ $euiControlBarBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorInk);
 $euiControlBarText: lighten(makeHighContrastColor($euiColorLightestShade, $euiControlBarBackground), 20%);
 $euiControlBarBorderColor: transparentize($euiColorGhost, .8);
 $euiControlBarInitialHeight: $euiSizeXXL;
+$euiControlBarMaxHeight: calc(100vh - #{$euiSize * 5});
+
+// Pixel heights ensure no blurriness caused by half pixel offsets
+$euiControlBarHeights: (
+  s: $euiSize * 15,
+  m: $euiSize * 30,
+  l: 100vh,
+);
+

--- a/src/components/control_bar/_variables.scss
+++ b/src/components/control_bar/_variables.scss
@@ -1,4 +1,4 @@
-$euiControlBarBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorInk);
-$euiControlBarText: lighten(makeHighContrastColor($euiColorLightestShade, $euiControlBarBackground), 20%);
-$euiControlBarBorderColor: transparentize($euiColorGhost, .8);
-$euiControlBarInitialHeight: $euiSizeXXL;
+$controlBarBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorInk);
+$controlBarText: lighten(makeHighContrastColor($euiColorLightestShade, $controlBarBackground), 20%);
+$controlBarBorderColor: rgba(255, 255, 255, .2);
+$controlBarInitialHeight: $euiSizeXXL;

--- a/src/components/control_bar/control_bar.test.tsx
+++ b/src/components/control_bar/control_bar.test.tsx
@@ -4,35 +4,76 @@ import { requiredProps, takeMountedSnapshot } from '../../test';
 
 import { EuiControlBar, Control } from './control_bar';
 
-const handleClick = () => {
-  console.log('You clicked');
-};
+// const handleClick = () => {
+//   console.log('You clicked');
+// };
 
 const controls: Control[] = [
   {
-    id: 'sound_the_alarm',
-    label: 'Sound the Alarm',
-    controlType: 'button',
-    onClick: handleClick,
+    id: 'current_file_path',
+    controlType: 'breadcrumbs',
+    responsive: true,
+    breadcrumbs: [
+      {
+        text: 'src',
+      },
+      {
+        text: 'components',
+      },
+    ],
   },
+  // {
+  //   id: 'sound_the_alarm',
+  //   label: 'Sound the Alarm',
+  //   controlType: 'button',
+  //   onClick: handleClick,
+  // },
+  // {
+  //   id: 'close_the_hatch',
+  //   label: 'Close the Hatch',
+  //   controlType: 'button',
+  //   onClick: handleClick,
+  // },
   {
+    controlType: 'text',
     id: 'close_the_hatch',
-    label: 'Close the Hatch',
-    controlType: 'button',
-    onClick: handleClick,
+    text: 'Close the Hatch',
+    'data-test-subj': 'dts',
   },
+  // {
+  //   controlType: 'icon',
+  //   id: 'sample_icon',
+  //   iconType: 'alert',
+  //   `aria-label`: 'Sample Icon',
+  // },
   {
-    id: 'sample_icon',
-    label: 'Sample Icon',
-    controlType: 'icon',
-    iconType: 'alert',
+    controlType: 'spacer',
   },
+  // {
+  //   id: 'status_icon',
+  //   label: 'Repo Status',
+  //   controlType: 'icon',
+  //   iconType: 'alert',
+  //   color: 'warning',
+  // },
 ];
 
 describe('EuiControlBar', () => {
   test('is rendered', () => {
     const component = takeMountedSnapshot(
       mount(<EuiControlBar controls={controls} {...requiredProps} />)
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe('mobile control bar', () => {
+  test('is rendered', () => {
+    const component = takeMountedSnapshot(
+      mount(
+        <EuiControlBar controls={controls} showOnMobile {...requiredProps} />
+      )
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/control_bar/control_bar.test.tsx
+++ b/src/components/control_bar/control_bar.test.tsx
@@ -22,13 +22,13 @@ const controls: Control[] = [
       },
     ],
   },
-  // {
-  //   controlType: 'button',
-  //   id: 'sound_the_alarm',
-  //   label: 'Sound the Alarm',
-  //   onClick: handleClick,
-  //   'data-test-subj': 'dts',
-  // },
+  {
+    controlType: 'button',
+    id: 'sound_the_alarm',
+    label: 'Sound the Alarm',
+    onClick: handleClick,
+    'data-test-subj': 'dts',
+  },
   {
     controlType: 'text',
     id: 'close_the_hatch',

--- a/src/components/control_bar/control_bar.test.tsx
+++ b/src/components/control_bar/control_bar.test.tsx
@@ -10,19 +10,6 @@ const handleClick = () => {
 
 const controls: Control[] = [
   {
-    id: 'current_file_path',
-    controlType: 'breadcrumbs',
-    responsive: true,
-    breadcrumbs: [
-      {
-        text: 'src',
-      },
-      {
-        text: 'components',
-      },
-    ],
-  },
-  {
     id: 'sound_the_alarm',
     label: 'Sound the Alarm',
     controlType: 'button',
@@ -40,34 +27,12 @@ const controls: Control[] = [
     controlType: 'icon',
     iconType: 'alert',
   },
-  {
-    controlType: 'spacer',
-  },
-  {
-    id: 'status_icon',
-    label: 'Repo Status',
-    controlType: 'icon',
-    iconType: 'alert',
-    color: 'warning',
-  },
 ];
 
 describe('EuiControlBar', () => {
   test('is rendered', () => {
     const component = takeMountedSnapshot(
       mount(<EuiControlBar controls={controls} {...requiredProps} />)
-    );
-
-    expect(component).toMatchSnapshot();
-  });
-});
-
-describe('mobile control bar', () => {
-  test('is rendered', () => {
-    const component = takeMountedSnapshot(
-      mount(
-        <EuiControlBar controls={controls} showOnMobile {...requiredProps} />
-      )
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/control_bar/control_bar.test.tsx
+++ b/src/components/control_bar/control_bar.test.tsx
@@ -4,14 +4,14 @@ import { requiredProps, takeMountedSnapshot } from '../../test';
 
 import { EuiControlBar, Control } from './control_bar';
 
-// const handleClick = () => {
-//   console.log('You clicked');
-// };
+const handleClick = () => {
+  console.log('You clicked');
+};
 
 const controls: Control[] = [
   {
-    id: 'current_file_path',
     controlType: 'breadcrumbs',
+    id: 'current_file_path',
     responsive: true,
     breadcrumbs: [
       {
@@ -23,39 +23,36 @@ const controls: Control[] = [
     ],
   },
   // {
+  //   controlType: 'button',
   //   id: 'sound_the_alarm',
   //   label: 'Sound the Alarm',
-  //   controlType: 'button',
   //   onClick: handleClick,
-  // },
-  // {
-  //   id: 'close_the_hatch',
-  //   label: 'Close the Hatch',
-  //   controlType: 'button',
-  //   onClick: handleClick,
+  //   'data-test-subj': 'dts',
   // },
   {
     controlType: 'text',
     id: 'close_the_hatch',
     text: 'Close the Hatch',
-    'data-test-subj': 'dts',
   },
-  // {
-  //   controlType: 'icon',
-  //   id: 'sample_icon',
-  //   iconType: 'alert',
-  //   `aria-label`: 'Sample Icon',
-  // },
+  {
+    controlType: 'divider',
+  },
+  {
+    controlType: 'icon',
+    id: 'sample_icon',
+    iconType: 'alert',
+    color: 'danger',
+    'aria-label': 'Sample Icon',
+  },
   {
     controlType: 'spacer',
   },
-  // {
-  //   id: 'status_icon',
-  //   label: 'Repo Status',
-  //   controlType: 'icon',
-  //   iconType: 'alert',
-  //   color: 'warning',
-  // },
+  {
+    controlType: 'tab',
+    id: 'flight_815',
+    label: 'Flight 815',
+    onClick: handleClick,
+  },
 ];
 
 describe('EuiControlBar', () => {
@@ -66,16 +63,74 @@ describe('EuiControlBar', () => {
 
     expect(component).toMatchSnapshot();
   });
-});
 
-describe('mobile control bar', () => {
-  test('is rendered', () => {
-    const component = takeMountedSnapshot(
-      mount(
-        <EuiControlBar controls={controls} showOnMobile {...requiredProps} />
-      )
-    );
+  describe('props', () => {
+    test('mobile is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} showOnMobile />
+      );
 
-    expect(component).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
+    });
+
+    test('showContent is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} showContent>
+          Content
+        </EuiControlBar>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('size is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} size="s">
+          Content
+        </EuiControlBar>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('maxHeight is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} maxHeight="20rem">
+          Content
+        </EuiControlBar>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('leftOffset is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} leftOffset={200}>
+          Content
+        </EuiControlBar>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('rightOffset is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} rightOffset={200}>
+          Content
+        </EuiControlBar>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('position is rendered', () => {
+      const component = mount(
+        <EuiControlBar controls={controls} position="absolute">
+          Content
+        </EuiControlBar>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -1,5 +1,5 @@
-import React, { Component, HTMLAttributes, ButtonHTMLAttributes } from 'react';
-import classnames from 'classnames';
+import React, { Component, HTMLAttributes } from 'react';
+import classNames from 'classnames';
 import { CommonProps, PropsOf, ExclusiveUnion } from '../common';
 // @ts-ignore-next-line
 import { EuiBreadcrumbs } from '../breadcrumbs';
@@ -8,21 +8,21 @@ import { EuiButton, EuiButtonIcon } from '../button';
 import { EuiPortal } from '../portal';
 import { EuiText } from '../text';
 
-type ButtonControl = ButtonHTMLAttributes<HTMLButtonElement> & {
+interface ButtonControl {
   controlType: 'button';
   id: string;
   color?: PropsOf<typeof EuiButton>['color'];
   label: string;
   classNames?: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-};
+}
 
-type TabControl = ButtonHTMLAttributes<HTMLButtonElement> & {
+interface TabControl {
   controlType: 'tab';
   id: string;
   label: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-};
+}
 
 interface Breadcrumb {
   text: string;
@@ -31,32 +31,34 @@ interface Breadcrumb {
   truncate?: boolean;
 }
 
-type BreadcrumbControl = HTMLAttributes<HTMLDivElement> & {
+interface BreadcrumbControl {
   controlType: 'breadcrumbs';
   id: string;
   responsive?: boolean;
   truncate?: boolean;
   max?: number;
   breadcrumbs: Breadcrumb[];
-};
+}
 
-type TextControl = HTMLAttributes<HTMLDivElement> & {
+interface TextControl {
   controlType: 'text';
   id: string;
   label: string;
   color?: PropsOf<typeof EuiText>['color'];
   onClick?: React.MouseEventHandler<HTMLDivElement>;
-};
+}
 
 interface SpacerControl {
   controlType: 'spacer';
+  id: string;
 }
 
 interface DivideControl {
   controlType: 'divider';
+  id: string;
 }
 
-type IconControl = ButtonHTMLAttributes<HTMLButtonElement> & {
+interface IconControl {
   controlType: 'icon';
   id: string;
   iconType: string;
@@ -64,7 +66,7 @@ type IconControl = ButtonHTMLAttributes<HTMLButtonElement> & {
   classNames?: string;
   color?: PropsOf<typeof EuiButtonIcon>['color'];
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-};
+}
 
 export type Control = ExclusiveUnion<
   ExclusiveUnion<
@@ -86,28 +88,22 @@ export type Control = ExclusiveUnion<
 export type EuiControlBarProps = HTMLAttributes<HTMLDivElement> &
   CommonProps & {
     /**
-     * Show or hide the content area containing the `children`
+     * Show or hide the content well with your custom content inside
      */
     showContent?: boolean;
 
     /**
-     * An array of controls, actions, and layout spacers to display.
-     * Accepts `'button' | 'tab' | 'breadcrumbs' | 'text' | 'icon' | 'spacer' | 'divider'`
+     * An array of controls, actions, and layout spacers to display
      */
     controls: Control[];
     /**
-     * The maximum height of the overlay. Default is 100% of the window height - 10rem, Medium is 50% of the window height, Small is 25% of the window height;
+     * The maximum height of the overlay. Default is 90%, Medium is 75%, Small is 50%;
      */
     size?: 's' | 'm' | 'l';
     /**
-     * Set the offset from the left side of the screen to account for EuiNavDrawer.
+     * Set the offset from the left side of the screen to account for Kibana's left-hand navigation menu.
      */
-    navDrawerOffset?: 'collapsed' | 'expanded' | undefined;
-    /**
-     * The control bar is hidden on mobile by default. Use the `showOnMobile` prop to force it's display on mobile screens.
-     * You'll need to ensure that the content you place into the bar renders as expected on mobile.
-     */
-    showOnMobile?: boolean;
+    leftOffset?: 's' | 'l' | undefined;
   };
 
 interface EuiControlBarState {
@@ -129,22 +125,20 @@ export class EuiControlBar extends Component<
       showContent,
       controls,
       size,
-      navDrawerOffset,
-      showOnMobile,
+      leftOffset,
       ...rest
     } = this.props;
 
-    const classes = classnames('euiControlBar', className, {
+    const classes = classNames('euiControlBar', className, {
       'euiControlBar--open': showContent,
       'euiControlBar--large': size === 'l' || !size,
       'euiControlBar--medium': size === 'm',
       'euiControlBar--small': size === 's',
-      'euiControlBar--navExpanded': navDrawerOffset === 'expanded',
-      'euiControlBar--navCollapsed': navDrawerOffset === 'collapsed',
-      'euiControlBar--showOnMobile': showOnMobile,
+      'euiControlBar--navExpanded': leftOffset === 'l',
+      'euiControlBar--navCollapsed': leftOffset === 's',
     });
 
-    const tabClasses = classnames('euiControlBar__tab', {
+    const tabClasses = classNames('euiControlBar__tab', {
       'euiControlBar__tab--active': showContent,
     });
 
@@ -164,60 +158,38 @@ export class EuiControlBar extends Component<
 
     const controlItem = (control: Control, index: number) => {
       switch (control.controlType) {
-        case 'button': {
-          const {
-            controlType,
-            id,
-            color,
-            label,
-            classNames,
-            onClick,
-            ...rest
-          } = control;
+        case 'button':
           return (
             <EuiButton
-              key={id + index}
-              onClick={onClick}
-              className={classnames('euiControlBar__button', classNames)}
-              color={color ? color : 'ghost'}
-              size="s"
-              {...rest}>
-              {label}
+              key={control.id + index}
+              aria-label={`Control Bar - ${control.label}`}
+              onClick={control.onClick}
+              data-test-subj={control.label}
+              className={classNames(
+                'euiControlBar__button',
+                control.classNames
+              )}
+              color={control.color ? control.color : 'ghost'}>
+              <EuiText size="s">{control.label}</EuiText>
             </EuiButton>
           );
-        }
-        case 'icon': {
-          const {
-            controlType,
-            id,
-            iconType,
-            label,
-            classNames,
-            color,
-            onClick,
-            ...rest
-          } = control;
+        case 'icon':
           return (
             <EuiButtonIcon
-              key={id + index}
-              iconType={iconType}
-              data-test-subj={label}
-              aria-label={label}
-              onClick={onClick}
-              className={classnames('euiControlBar__buttonIcon', classNames)}
-              color={color ? color : 'ghost'}
-              size="s"
-              {...rest}
+              key={control.id + index}
+              iconType={control.iconType}
+              data-test-subj={control.label}
+              aria-label={control.label}
+              onClick={control.onClick}
+              className={classNames(
+                'euiControlBar__buttonIcon',
+                control.classNames
+              )}
+              color={control.color ? control.color : 'ghost'}
             />
           );
-        }
         case 'divider':
-          return (
-            <div
-              key={control.controlType + index}
-              className="euiControlBar__divider"
-            />
-          );
+          return <div key={control.id} className="euiControlBar__divider" />;
         case 'spacer':
           return (
             <div
@@ -225,47 +197,30 @@ export class EuiControlBar extends Component<
               className="euiControlBar__spacer"
             />
           );
-        case 'text': {
-          const { controlType, id, label, color, onClick, ...rest } = control;
+        case 'text':
           return (
             <EuiText
-              color={color ? color : 'ghost'}
-              className="euiControlBar__euiText eui-textTruncate"
-              key={id + index}
-              size="s"
-              {...rest}>
-              {label}
+              color={control.color ? control.color : 'ghost'}
+              className="euiControlBar__euiText"
+              key={control.id + index}
+              size="s">
+              {control.label}
             </EuiText>
           );
-        }
-        case 'tab': {
-          const { controlType, id, label, onClick, ...rest } = control;
+        case 'tab':
           return (
             <button
-              key={id + index}
+              key={control.id + index}
               className={`euiControlBar__tab ${
-                id === this.state.selectedTab ? tabClasses : ''
+                control.id === this.state.selectedTab ? tabClasses : ''
               }`}
-              data-test-subj={label}
-              aria-label={`Control Bar - ${label}`}
-              onClick={event => handleTabClick(control, event)}
-              {...rest}>
-              <EuiText size="s" className="eui-textTruncate">
-                {label}
-              </EuiText>
+              data-test-subj={control.label}
+              aria-label={`Control Bar - ${control.label}`}
+              onClick={event => handleTabClick(control, event)}>
+              <EuiText size="s">{control.label}</EuiText>
             </button>
           );
-        }
-        case 'breadcrumbs': {
-          const {
-            controlType,
-            id,
-            responsive,
-            truncate,
-            max,
-            breadcrumbs,
-            ...rest
-          } = control;
+        case 'breadcrumbs':
           return (
             <EuiBreadcrumbs
               key={control.id}
@@ -273,16 +228,14 @@ export class EuiControlBar extends Component<
               responsive={control.responsive}
               truncate={control.truncate}
               max={control.max}
-              {...rest}
             />
           );
-        }
       }
     };
 
     return (
       <EuiPortal>
-        <div className={classes} {...rest}>
+        <div className={classes} aria-label="Control Bar" {...rest}>
           <div className="euiControlBar__controls">
             {controls.map((control, index) => {
               return controlItem(control, index);

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -1,12 +1,18 @@
 import React, { Component, HTMLAttributes, ButtonHTMLAttributes } from 'react';
-import classnames from 'classnames';
-import { CommonProps, PropsOf, ExclusiveUnion } from '../common';
+import classNames from 'classnames';
+import { CommonProps, ExclusiveUnion, Omit } from '../common';
 // @ts-ignore-next-line
 import { EuiBreadcrumbs } from '../breadcrumbs';
-// @ts-ignore-next-line
-import { EuiButton, EuiButtonIcon } from '../button';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiButtonProps,
+  EuiButtonIconProps,
+} from '../button';
 import { EuiPortal } from '../portal';
 import { EuiText } from '../text';
+import { EuiIcon } from '../icon';
+import { EuiIconProps } from '../icon/icon';
 
 type ButtonControl = ButtonHTMLAttributes<HTMLButtonElement> & {
   controlType: 'button';
@@ -50,19 +56,28 @@ interface SpacerControl {
   controlType: 'spacer';
 }
 
-interface DivideControl {
+interface DividerControl {
   controlType: 'divider';
 }
 
-type IconControl = ButtonHTMLAttributes<HTMLButtonElement> & {
+interface IconControlProps {
   controlType: 'icon';
   id: string;
   iconType: string;
-  label: string;
-  classNames?: string;
-  color?: PropsOf<typeof EuiButtonIcon>['color'];
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-};
+}
+interface IconControlType
+  extends Omit<EuiIconProps, 'type'>,
+    IconControlProps {}
+interface IconButtonControlType
+  extends Omit<EuiButtonIconProps, 'iconType'>,
+    IconControlProps {
+  href?: string;
+}
+
+export type IconControl = ExclusiveUnion<
+  IconControlType,
+  IconButtonControlType
+>;
 
 export type Control = ExclusiveUnion<
   ExclusiveUnion<
@@ -76,7 +91,7 @@ export type Control = ExclusiveUnion<
       >,
       IconControl
     >,
-    DivideControl
+    DividerControl
   >,
   SpacerControl
 >;
@@ -132,7 +147,7 @@ export class EuiControlBar extends Component<
       ...rest
     } = this.props;
 
-    const classes = classnames('euiControlBar', className, {
+    const classes = classNames('euiControlBar', className, {
       'euiControlBar--open': showContent,
       'euiControlBar--large': size === 'l' || !size,
       'euiControlBar--medium': size === 'm',
@@ -142,7 +157,7 @@ export class EuiControlBar extends Component<
       'euiControlBar--showOnMobile': showOnMobile,
     });
 
-    const tabClasses = classnames('euiControlBar__tab', {
+    const tabClasses = classNames('euiControlBar__tab', {
       'euiControlBar__tab--active': showContent,
     });
 
@@ -189,22 +204,29 @@ export class EuiControlBar extends Component<
             controlType,
             id,
             iconType,
-            label,
-            classNames,
-            color,
+            className,
+            color = 'ghost',
             onClick,
+            href,
             ...rest
           } = control;
-          return (
+          return onClick || href ? (
             <EuiButtonIcon
               key={id + index}
+              className={classNames('euiControlBar__buttonIcon', className)}
               iconType={iconType}
-              data-test-subj={label}
-              aria-label={label}
               onClick={onClick}
-              className={classnames('euiControlBar__buttonIcon', classNames)}
-              color={color ? color : 'ghost'}
+              href={href}
+              color={color as EuiButtonIconProps['color']}
+              {...rest as IconButtonControlType}
               size="s"
+            />
+          ) : (
+            <EuiIcon
+              key={id + index}
+              className={classNames('euiControlBar__icon', className)}
+              type={iconType}
+              color={color}
               {...rest}
             />
           );

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -40,13 +40,11 @@ type BreadcrumbControl = HTMLAttributes<HTMLDivElement> & {
   breadcrumbs: Breadcrumb[];
 };
 
-type TextControl = HTMLAttributes<HTMLDivElement> & {
+interface TextControl extends CommonProps, HTMLAttributes<HTMLDivElement> {
   controlType: 'text';
   id: string;
-  label: string;
-  color?: PropsOf<typeof EuiText>['color'];
-  onClick?: React.MouseEventHandler<HTMLDivElement>;
-};
+  label: React.ReactNode;
+}
 
 interface SpacerControl {
   controlType: 'spacer';
@@ -226,16 +224,14 @@ export class EuiControlBar extends Component<
             />
           );
         case 'text': {
-          const { controlType, id, label, color, onClick, ...rest } = control;
+          const { controlType, id, label, className, ...rest } = control;
           return (
-            <EuiText
-              color={color ? color : 'ghost'}
-              className="euiControlBar__euiText eui-textTruncate"
-              key={id + index}
-              size="s"
+            <div
+              key={id}
+              className={classNames('euiControlBar__euiText', className)}
               {...rest}>
               {label}
-            </EuiText>
+            </div>
           );
         }
         case 'tab': {

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -1,6 +1,17 @@
-import React, { Component, HTMLAttributes, ButtonHTMLAttributes } from 'react';
+import React, {
+  Component,
+  HTMLAttributes,
+  ButtonHTMLAttributes,
+  Ref,
+} from 'react';
 import classNames from 'classnames';
-import { CommonProps, ExclusiveUnion, Omit } from '../common';
+import {
+  CommonProps,
+  ExclusiveUnion,
+  Omit,
+  PropsForAnchor,
+  PropsForButton,
+} from '../common';
 // @ts-ignore-next-line
 import { EuiBreadcrumbs, EuiBreadcrumbsProps } from '../breadcrumbs';
 import {
@@ -21,6 +32,25 @@ export interface ButtonControl extends Omit<EuiButtonProps, 'size'> {
   id: string;
   label: React.ReactNode;
 }
+
+type ButtonPropsForAnchor = PropsForAnchor<
+  ButtonControl,
+  {
+    buttonRef?: Ref<HTMLAnchorElement>;
+  }
+>;
+
+type ButtonPropsForButton = PropsForButton<
+  ButtonControl,
+  {
+    buttonRef?: Ref<HTMLButtonElement>;
+  }
+>;
+
+type ButtonControlProps = ExclusiveUnion<
+  ButtonPropsForAnchor,
+  ButtonPropsForButton
+>;
 
 /**
  * Creates a `button` visually styles as a tab.
@@ -98,7 +128,7 @@ export type Control = ExclusiveUnion<
     ExclusiveUnion<
       ExclusiveUnion<
         ExclusiveUnion<
-          ButtonControl,
+          ButtonControlProps,
           ExclusiveUnion<BreadcrumbControl, TabControl>
         >,
         TextControl

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -13,51 +13,78 @@ import { EuiPortal } from '../portal';
 import { EuiIcon } from '../icon';
 import { EuiIconProps } from '../icon/icon';
 
-interface ButtonControl extends Omit<EuiButtonProps, 'size'> {
+/**
+ * Extends EuiButton excluding `size`. Requires `label` as the `children`.
+ */
+export interface ButtonControl extends Omit<EuiButtonProps, 'size'> {
   controlType: 'button';
   id: string;
   label: React.ReactNode;
 }
 
-type TabControl = ButtonHTMLAttributes<HTMLButtonElement> & {
+/**
+ * Creates a `button` visually styles as a tab.
+ * Requires `label` as the `children`.
+ * `onClick` must be provided to handle the content swapping.
+ */
+export type TabControl = ButtonHTMLAttributes<HTMLButtonElement> & {
   controlType: 'tab';
   id: string;
   label: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-interface BreadcrumbControl extends EuiBreadcrumbsProps {
+/**
+ * Extends EuiBreadcrumbs
+ */
+export interface BreadcrumbControl extends EuiBreadcrumbsProps {
   controlType: 'breadcrumbs';
   id: string;
 }
 
-interface TextControl extends CommonProps, HTMLAttributes<HTMLDivElement> {
+/**
+ * Simple div controlling color and size text output.
+ * Requires `label` as the `children`.
+ */
+export interface TextControl
+  extends CommonProps,
+    HTMLAttributes<HTMLDivElement> {
   controlType: 'text';
   id: string;
   label: React.ReactNode;
 }
 
-interface SpacerControl {
+export interface SpacerControl {
   controlType: 'spacer';
 }
 
-interface DividerControl {
+export interface DividerControl {
   controlType: 'divider';
 }
 
-interface IconControlProps {
+/**
+ * Custom props specific to the icon control type
+ */
+export interface IconControlProps {
   controlType: 'icon';
   id: string;
   iconType: string;
 }
-interface IconControlType
+/**
+ * Icon can extend EuiIcon
+ * Had to omit `onClick` as it's a valid prop of SVGElement
+ * Also omits `type` and `id` as these are also specific to icon control
+ */
+export interface IconControlType
   extends Omit<EuiIconProps, 'type' | 'id' | 'onClick'>,
     IconControlProps {}
-interface IconButtonControlType
+/**
+ * Icon can extend EuiButtonIcon
+ * Also omits `iconType` and `id` as these are also specific to icon control
+ */
+export interface IconButtonControlType
   extends Omit<EuiButtonIconProps, 'iconType' | 'id'>,
-    IconControlProps {
-  href?: string;
-}
+    IconControlProps {}
 
 export type IconControl = ExclusiveUnion<
   IconControlType,
@@ -98,9 +125,13 @@ export type EuiControlBarProps = HTMLAttributes<HTMLDivElement> &
      */
     size?: 's' | 'm' | 'l';
     /**
-     * Set the offset from the left side of the screen to account for EuiNavDrawer.
+     * Set the offset from the left side of the screen.
      */
-    navDrawerOffset?: 'collapsed' | 'expanded' | undefined;
+    leftOffset?: number | string;
+    /**
+     * Set the offset from the left side of the screen.
+     */
+    rightOffset?: number | string;
     /**
      * The control bar is hidden on mobile by default. Use the `showOnMobile` prop to force it's display on mobile screens.
      * You'll need to ensure that the content you place into the bar renders as expected on mobile.
@@ -127,18 +158,20 @@ export class EuiControlBar extends Component<
       showContent,
       controls,
       size,
-      navDrawerOffset,
+      leftOffset = 0,
+      rightOffset = 0,
       showOnMobile,
+      style,
       ...rest
     } = this.props;
 
+    const styles = { ...style, left: leftOffset, right: rightOffset };
+
     const classes = classNames('euiControlBar', className, {
-      'euiControlBar--open': showContent,
+      'euiControlBar-isOpen': showContent,
       'euiControlBar--large': size === 'l' || !size,
       'euiControlBar--medium': size === 'm',
       'euiControlBar--small': size === 's',
-      'euiControlBar--navExpanded': navDrawerOffset === 'expanded',
-      'euiControlBar--navCollapsed': navDrawerOffset === 'collapsed',
       'euiControlBar--showOnMobile': showOnMobile,
     });
 
@@ -273,7 +306,7 @@ export class EuiControlBar extends Component<
 
     return (
       <EuiPortal>
-        <div className={classes} {...rest}>
+        <div className={classes} {...rest} style={styles}>
           <div className="euiControlBar__controls">
             {controls.map((control, index) => {
               return controlItem(control, index);

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -14,14 +14,11 @@ import { EuiText } from '../text';
 import { EuiIcon } from '../icon';
 import { EuiIconProps } from '../icon/icon';
 
-type ButtonControl = ButtonHTMLAttributes<HTMLButtonElement> & {
+interface ButtonControl extends Omit<EuiButtonProps, 'size'> {
   controlType: 'button';
   id: string;
-  color?: PropsOf<typeof EuiButton>['color'];
-  label: string;
-  classNames?: string;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-};
+  label: React.ReactNode;
+}
 
 type TabControl = ButtonHTMLAttributes<HTMLButtonElement> & {
   controlType: 'tab';
@@ -181,20 +178,18 @@ export class EuiControlBar extends Component<
           const {
             controlType,
             id,
-            color,
+            color = 'ghost',
             label,
-            classNames,
-            onClick,
+            className,
             ...rest
           } = control;
           return (
             <EuiButton
               key={id + index}
-              onClick={onClick}
-              className={classnames('euiControlBar__button', classNames)}
-              color={color ? color : 'ghost'}
-              size="s"
-              {...rest}>
+              className={classNames('euiControlBar__button', className)}
+              color={color}
+              {...rest}
+              size="s">
               {label}
             </EuiButton>
           );
@@ -250,7 +245,7 @@ export class EuiControlBar extends Component<
           return (
             <div
               key={id}
-              className={classNames('euiControlBar__euiText', className)}
+              className={classNames('euiControlBar__text', className)}
               {...rest}>
               {label}
             </div>

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -2,7 +2,7 @@ import React, { Component, HTMLAttributes, ButtonHTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion, Omit } from '../common';
 // @ts-ignore-next-line
-import { EuiBreadcrumbs } from '../breadcrumbs';
+import { EuiBreadcrumbs, EuiBreadcrumbsProps } from '../breadcrumbs';
 import {
   EuiButton,
   EuiButtonIcon,
@@ -10,7 +10,6 @@ import {
   EuiButtonIconProps,
 } from '../button';
 import { EuiPortal } from '../portal';
-import { EuiText } from '../text';
 import { EuiIcon } from '../icon';
 import { EuiIconProps } from '../icon/icon';
 
@@ -23,25 +22,14 @@ interface ButtonControl extends Omit<EuiButtonProps, 'size'> {
 type TabControl = ButtonHTMLAttributes<HTMLButtonElement> & {
   controlType: 'tab';
   id: string;
-  label: string;
+  label: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-interface Breadcrumb {
-  text: string;
-  href?: string;
-  onClick?: React.MouseEventHandler<HTMLDivElement>;
-  truncate?: boolean;
-}
-
-type BreadcrumbControl = HTMLAttributes<HTMLDivElement> & {
+interface BreadcrumbControl extends EuiBreadcrumbsProps {
   controlType: 'breadcrumbs';
   id: string;
-  responsive?: boolean;
-  truncate?: boolean;
-  max?: number;
-  breadcrumbs: Breadcrumb[];
-};
+}
 
 interface TextControl extends CommonProps, HTMLAttributes<HTMLDivElement> {
   controlType: 'text';
@@ -63,10 +51,10 @@ interface IconControlProps {
   iconType: string;
 }
 interface IconControlType
-  extends Omit<EuiIconProps, 'type'>,
+  extends Omit<EuiIconProps, 'type' | 'id' | 'onClick'>,
     IconControlProps {}
 interface IconButtonControlType
-  extends Omit<EuiButtonIconProps, 'iconType'>,
+  extends Omit<EuiButtonIconProps, 'iconType' | 'id'>,
     IconControlProps {
   href?: string;
 }
@@ -152,10 +140,6 @@ export class EuiControlBar extends Component<
       'euiControlBar--navExpanded': navDrawerOffset === 'expanded',
       'euiControlBar--navCollapsed': navDrawerOffset === 'collapsed',
       'euiControlBar--showOnMobile': showOnMobile,
-    });
-
-    const tabClasses = classNames('euiControlBar__tab', {
-      'euiControlBar__tab--active': showContent,
     });
 
     const handleTabClick = (
@@ -252,43 +236,37 @@ export class EuiControlBar extends Component<
           );
         }
         case 'tab': {
-          const { controlType, id, label, onClick, ...rest } = control;
+          const {
+            controlType,
+            id,
+            label,
+            onClick,
+            className,
+            ...rest
+          } = control;
+
+          const tabClasses = classNames(
+            'euiControlBar__tab',
+            {
+              'euiControlBar__tab--active':
+                showContent && id === this.state.selectedTab,
+            },
+            className
+          );
+
           return (
             <button
               key={id + index}
-              className={`euiControlBar__tab ${
-                id === this.state.selectedTab ? tabClasses : ''
-              }`}
-              data-test-subj={label}
-              aria-label={`Control Bar - ${label}`}
+              className={tabClasses}
               onClick={event => handleTabClick(control, event)}
               {...rest}>
-              <EuiText size="s" className="eui-textTruncate">
-                {label}
-              </EuiText>
+              {label}
             </button>
           );
         }
         case 'breadcrumbs': {
-          const {
-            controlType,
-            id,
-            responsive,
-            truncate,
-            max,
-            breadcrumbs,
-            ...rest
-          } = control;
-          return (
-            <EuiBreadcrumbs
-              key={control.id}
-              breadcrumbs={control.breadcrumbs}
-              responsive={control.responsive}
-              truncate={control.truncate}
-              max={control.max}
-              {...rest}
-            />
-          );
+          const { controlType, id, ...rest } = control;
+          return <EuiBreadcrumbs key={control.id} {...rest} />;
         }
       }
     };

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -70,6 +70,7 @@ export interface IconControlProps {
   id: string;
   iconType: string;
 }
+
 /**
  * Icon can extend EuiIcon
  * Had to omit `onClick` as it's a valid prop of SVGElement
@@ -78,6 +79,7 @@ export interface IconControlProps {
 export interface IconControlType
   extends Omit<EuiIconProps, 'type' | 'id' | 'onClick'>,
     IconControlProps {}
+
 /**
  * Icon can extend EuiButtonIcon
  * Also omits `iconType` and `id` as these are also specific to icon control
@@ -168,6 +170,14 @@ export class EuiControlBar extends Component<
   EuiControlBarProps,
   EuiControlBarState
 > {
+  static defaultProps = {
+    leftOffset: 0,
+    rightOffset: 0,
+    position: 'fixed',
+    size: 'l',
+    showContent: false,
+    showOnMobile: false,
+  };
   private bar: HTMLDivElement | null = null;
 
   componentDidMount() {
@@ -198,12 +208,12 @@ export class EuiControlBar extends Component<
       showContent,
       controls,
       size,
-      leftOffset = 0,
-      rightOffset = 0,
+      leftOffset,
+      rightOffset,
       maxHeight,
       showOnMobile,
       style,
-      position = 'fixed',
+      position,
       bodyClassName,
       ...rest
     } = this.props;
@@ -217,7 +227,7 @@ export class EuiControlBar extends Component<
 
     const classes = classNames('euiControlBar', className, {
       'euiControlBar-isOpen': showContent,
-      'euiControlBar--large': size === 'l' || !size,
+      'euiControlBar--large': size === 'l',
       'euiControlBar--medium': size === 'm',
       'euiControlBar--small': size === 's',
       'euiControlBar--fixed': position === 'fixed',

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -120,18 +120,28 @@ export type EuiControlBarProps = HTMLAttributes<HTMLDivElement> &
      * Accepts `'button' | 'tab' | 'breadcrumbs' | 'text' | 'icon' | 'spacer' | 'divider'`
      */
     controls: Control[];
+
     /**
-     * The maximum height of the overlay. Default is 100% of the window height - 10rem, Medium is 50% of the window height, Small is 25% of the window height;
+     * The default height of the content area.
      */
     size?: 's' | 'm' | 'l';
+
+    /**
+     * Customize the max height.
+     * Best when used with `size=l` as this will ensure the actual height equals the max height set.
+     */
+    maxHeight?: number | string;
+
     /**
      * Set the offset from the left side of the screen.
      */
     leftOffset?: number | string;
+
     /**
      * Set the offset from the left side of the screen.
      */
     rightOffset?: number | string;
+
     /**
      * The control bar is hidden on mobile by default. Use the `showOnMobile` prop to force it's display on mobile screens.
      * You'll need to ensure that the content you place into the bar renders as expected on mobile.
@@ -190,6 +200,7 @@ export class EuiControlBar extends Component<
       size,
       leftOffset = 0,
       rightOffset = 0,
+      maxHeight,
       showOnMobile,
       style,
       position = 'fixed',
@@ -197,7 +208,12 @@ export class EuiControlBar extends Component<
       ...rest
     } = this.props;
 
-    const styles = { ...style, left: leftOffset, right: rightOffset };
+    const styles = {
+      ...style,
+      left: leftOffset,
+      right: rightOffset,
+      maxHeight: maxHeight,
+    };
 
     const classes = classNames('euiControlBar', className, {
       'euiControlBar-isOpen': showContent,

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -28,7 +28,6 @@ import { EuiIconProps } from '../icon/icon';
  * Extends EuiButton excluding `size`. Requires `label` as the `children`.
  */
 export interface ButtonControl extends Omit<EuiButtonProps, 'size'> {
-  controlType: 'button';
   id: string;
   label: React.ReactNode;
 }
@@ -50,7 +49,9 @@ type ButtonPropsForButton = PropsForButton<
 type ButtonControlProps = ExclusiveUnion<
   ButtonPropsForAnchor,
   ButtonPropsForButton
->;
+> & {
+  controlType: 'button';
+};
 
 /**
  * Creates a `button` visually styles as a tab.

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -51,7 +51,7 @@ export interface TextControl
     HTMLAttributes<HTMLDivElement> {
   controlType: 'text';
   id: string;
-  label: React.ReactNode;
+  text: React.ReactNode;
 }
 
 export interface SpacerControl {
@@ -309,13 +309,13 @@ export class EuiControlBar extends Component<
             />
           );
         case 'text': {
-          const { controlType, id, label, className, ...rest } = control;
+          const { controlType, id, text, className, ...rest } = control;
           return (
             <div
               key={id}
               className={classNames('euiControlBar__text', className)}
               {...rest}>
-              {label}
+              {text}
             </div>
           );
         }

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -53,14 +53,11 @@
 /**
  *  Responsive
  *
- *  3. Be sure to hide/show the element initially
+ *  1. Be sure to hide the element initially
  */
-[class*='eui-hideFor'] {
-  display: inherit !important; /* 3 */
-}
 
 [class*='eui-showFor'] {
-  display: none !important; /* 3 */
+  display: none !important; /* 1 */
 }
 
 @each $size in $euiBreakpointKeys {


### PR DESCRIPTION
There's a lot of commits because I wanted to be sure I documented my changes. The main changes are:

1. Fixed up TS types where they now extend from their EUI component that they render
2. Changed `navDrawerOffset` to generic `leftOffset` and `rightOffset`
3. Added `position` prop so consumers could change the parent of the control bar (instead of always being fixed positioned).
4. Changed the sizes to be pixel amounts so that they're never on a half pixel. Dave might have a better solution for this. But I think this in conjunction with the new `maxHeight` prop will give the consumers the ability to change the size to their needs.
5. Beefed up the tests
6. Removed the full screen style of docs examples and just display/show the control bar within the docs page with a button or `position: relative`